### PR TITLE
Add jump to bottom button in chat

### DIFF
--- a/moxin-frontend/resources/icons/jump_to_bottom.svg
+++ b/moxin-frontend/resources/icons/jump_to_bottom.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 7.4L0 1.4L1.4 0L6 4.6L10.6 0L12 1.4L6 7.4Z" fill="#1C1B1F"/>
+</svg>


### PR DESCRIPTION
This is a quick addition of the feature, but with some limitations because we don't have yet a reliable way to track if the scroll is at the end in the PortalList (I need to do more research).
Also, styling will need to be reworked because the Figma design has a shadow effect hard to archive in Makepad.