### PR TITLE
[On hold] Better default downloads path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/moxin-backend/*.db

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -109,19 +109,13 @@ live_design! {
 
 app_main!(App);
 
-#[derive(Live)]
+#[derive(Live, LiveHook)]
 pub struct App {
     #[live]
     ui: WidgetRef,
 
     #[rust]
     store: Store,
-}
-
-impl LiveHook for App {
-    fn after_new_from_doc(&mut self, _cx: &mut Cx) {
-        self.store = Store::new();
-    }
 }
 
 impl LiveRegister for App {

--- a/moxin-frontend/src/my_models/my_models_screen.rs
+++ b/moxin-frontend/src/my_models/my_models_screen.rs
@@ -108,7 +108,7 @@ live_design! {
         }
 
         input = <TextInput> {
-            width: 260,
+            width: 250,
             height: Fit,
 
             empty_message: "Search Model by Keyword"
@@ -219,6 +219,7 @@ live_design! {
             align: {x: 0.0, y: 0.5}
 
             <Label> {
+                width: Fit, height: Fit
                 draw_text:{
                     text_style: <REGULAR_FONT>{font_size: 11}
                     color: #000
@@ -226,16 +227,17 @@ live_design! {
                 text: "Local Models Folder"
             }
             local_models_folder = <Label> {
+                width: 300, height: Fit
                 draw_text:{
                     text_style: <REGULAR_FONT>{font_size: 11}
                     color: #222
+                    wrap: Ellipsis
                 }
-                text: "/Users/name/.cache/lm-studio/models"
             }
 
             <DownloadLocation> {}
             <ReviewInFinder> {}
-            <View> { width: Fill, height: Fit }
+            <View> { width: Fill }
             <SearchBar> {}
         }
 
@@ -257,11 +259,14 @@ impl Widget for MyModelsScreen {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        let downloaded_files = &scope.data.get::<Store>().unwrap().downloaded_files;
+        let store = &scope.data.get::<Store>().unwrap();
 
-        let summary = generate_models_summary(&downloaded_files);
+        let summary = generate_models_summary(&&store.downloaded_files);
         let models_summary_label = self.view.label(id!(header.models_summary));
         models_summary_label.set_text(&summary);
+
+        let models_folder_label = self.view.label(id!(sub_header.local_models_folder));
+        models_folder_label.set_text(&store.downloaded_files_folder);
 
         self.view.draw_walk(cx, scope, walk)
     }


### PR DESCRIPTION
Sets the default downloads path using $HOME/moxin/model_downloads, it currently uses the current directory.

Stores the path in the current Store so it can be used for display.

![image](https://github.com/project-robius/moxin/assets/22042418/5299619d-0e37-487a-aae0-514869e96a2d)