### PR TITLE
Add proper formatting of model sizes

### DIFF
--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -1,4 +1,7 @@
-use crate::{data::store::{Store, StoreAction}, shared::utils::format_model_size};
+use crate::{
+    data::store::{Store, StoreAction},
+    shared::utils::format_model_size,
+};
 use makepad_widgets::*;
 use moxin_protocol::data::{File, Model};
 use std::collections::HashMap;

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -1,4 +1,4 @@
-use crate::data::store::{Store, StoreAction};
+use crate::{data::store::{Store, StoreAction}, shared::utils::format_model_size};
 use makepad_widgets::*;
 use moxin_protocol::data::{File, Model};
 use std::collections::HashMap;
@@ -422,7 +422,7 @@ impl ModelFilesItems {
             self.map_to_files.insert(item_id, files[i].clone());
 
             let filename = &files[i].name;
-            let size = &files[i].size;
+            let size = format_model_size(&files[i].size).unwrap_or("-".to_string());
             let quantization = &files[i].quantization;
             item_widget.apply_over(
                 cx,

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -259,7 +259,8 @@ impl Widget for DownloadedFilesTable {
                             .set_text(quantization);
 
                         // File size tag
-                        let file_size = format_model_size(&file_data.file.size).unwrap_or("-".to_string());
+                        let file_size =
+                            format_model_size(&file_data.file.size).unwrap_or("-".to_string());
                         item.label(id!(wrapper.file_size_tag.file_size))
                             .set_text(&file_size);
 

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use makepad_widgets::*;
 use moxin_protocol::data::DownloadedFile;
 
-use crate::data::store::Store;
+use crate::{data::store::Store, shared::utils::format_model_size};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -259,9 +259,9 @@ impl Widget for DownloadedFilesTable {
                             .set_text(quantization);
 
                         // File size tag
-                        let file_size = dash_if_empty(&file_data.file.size);
+                        let file_size = format_model_size(&file_data.file.size).unwrap_or("-".to_string());
                         item.label(id!(wrapper.file_size_tag.file_size))
-                            .set_text(file_size);
+                            .set_text(&file_size);
 
                         // Compatibility guess tag
                         item.label(id!(wrapper.compatibility_guess_tag.compatibility.attr_name))

--- a/moxin-frontend/src/my_models/my_models_screen.rs
+++ b/moxin-frontend/src/my_models/my_models_screen.rs
@@ -272,7 +272,7 @@ fn generate_models_summary(downloaded_files: &Vec<DownloadedFile>) -> String {
     let disk_space_label = if total_diskspace_mb >= 1024.0 {
         format!("{:.2} GB Diskspace", total_diskspace_mb / 1024.0)
     } else {
-        format!("{:.2} MB Diskspace", total_diskspace_mb)
+        format!("{} MB Diskspace", total_diskspace_mb as i32)
     };
 
     let model_label = if downloaded_files.len() == 1 {
@@ -291,7 +291,6 @@ fn generate_models_summary(downloaded_files: &Vec<DownloadedFile>) -> String {
 
 fn total_files_disk_space(files: &Vec<DownloadedFile>) -> f64 {
     files.iter().fold(0., |acc, file| {
-        log!("FILE SIZE: {}", file.file.size);
         let file_size_bytes = file.file.size.parse::<f64>();
         match file_size_bytes {
             Ok(size_bytes) => acc + (size_bytes / BYTES_PER_MB),

--- a/moxin-frontend/src/shared/mod.rs
+++ b/moxin-frontend/src/shared/mod.rs
@@ -1,3 +1,4 @@
 pub mod icon;
 pub mod styles;
+pub mod utils;
 pub mod widgets;

--- a/moxin-frontend/src/shared/utils.rs
+++ b/moxin-frontend/src/shared/utils.rs
@@ -8,6 +8,6 @@ pub fn format_model_size(size: &str) -> Result<String> {
     if size_mb >= 1024.0 {
         Ok(format!("{:.2} GB", size_mb / 1024.0))
     } else {
-        Ok(format!("{:.2} MB", size_mb))
+        Ok(format!("{:.2} MB", size_mb as i32))
     }
 }

--- a/moxin-frontend/src/shared/utils.rs
+++ b/moxin-frontend/src/shared/utils.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+pub const BYTES_PER_MB: f64 = 1_048_576.0; // (1024^2)
+
+pub fn format_model_size(size: &str) -> Result<String> {
+    let size_mb = size.parse::<f64>()? / BYTES_PER_MB;
+
+    if size_mb >= 1024.0 {
+        Ok(format!("{:.2} GB", size_mb / 1024.0))
+    } else {
+        Ok(format!("{:.2} MB", size_mb))
+    }
+}


### PR DESCRIPTION
I noticed that currently most models are providing their file size, however it is now in provided in bytes instead of formatted to GB like before, i.e. `1.09 GB` is now `1095216660`

This PR updates the Modes Files List in the landing page, and My Models screen (header and table) with proper formatting.

Files list in landing screen:

![Screenshot 2024-04-12 at 14 32 17](https://github.com/project-robius/moxin/assets/22042418/384e2872-4115-4d30-a177-bc470334acd9)


My Models:
(In the header, if the total diskspace is < 1GB it will format to MB, i.g. `1 Model, 459 MB Diskpace`)

![Screenshot 2024-04-12 at 14 31 39](https://github.com/project-robius/moxin/assets/22042418/4727af69-8757-4842-92db-9a67ada91ec7)


