### PR TITLE
My Models - Add model info modal

### DIFF
--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -4,6 +4,7 @@ use crate::landing::model_card::{ModelCardViewAllModalWidgetRefExt, ViewAllModal
 use crate::landing::model_files_list::ModelFileItemsAction;
 use crate::my_models::delete_model_modal::{DeleteModelAction, DeleteModelModalWidgetRefExt};
 use crate::my_models::downloaded_files_table::DownloadedFileAction;
+use crate::my_models::model_info_modal::{ModelInfoAction, ModelInfoModalWidgetRefExt};
 use makepad_widgets::*;
 
 live_design! {
@@ -17,6 +18,7 @@ live_design! {
     import crate::chat::chat_screen::ChatScreen;
     import crate::my_models::my_models_screen::MyModelsScreen;
     import crate::my_models::delete_model_modal::DeleteModelModal;
+    import crate::my_models::model_info_modal::ModelInfoModal;
 
 
     ICON_DISCOVER = dep("crate://self/resources/icons/discover.svg")
@@ -128,6 +130,12 @@ live_design! {
                             delete_model_modal = <DeleteModelModal> {}
                         }
                     }
+
+                    model_info_modal_view = <ModalView> {
+                        content = {
+                            model_info_modal = <ModelInfoModal> {}
+                        }
+                    }
                 }
             }
         }
@@ -184,6 +192,7 @@ impl LiveRegister for App {
         crate::my_models::my_models_screen::live_design(cx);
         crate::my_models::downloaded_files_table::live_design(cx);
         crate::my_models::delete_model_modal::live_design(cx);
+        crate::my_models::model_info_modal::live_design(cx);
     }
 }
 
@@ -269,6 +278,14 @@ impl MatchEvent for App {
             // Set modal viewall model id
             if let DeleteModelAction::FileSelected(file_id) = action.as_widget_action().cast() {
                 let mut modal = self.ui.delete_model_modal(id!(delete_model_modal));
+                modal.set_file_id(file_id);
+                // TODO: Hack for error that when you first open the modal, doesnt draw until an event
+                // this forces the entire ui to rerender, still weird that only happens the first time.
+                self.ui.redraw(cx);
+            }
+
+            if let ModelInfoAction::FileSelected(file_id) = action.as_widget_action().cast() {
+                let mut modal = self.ui.model_info_modal(id!(model_info_modal));
                 modal.set_file_id(file_id);
                 // TODO: Hack for error that when you first open the modal, doesnt draw until an event
                 // this forces the entire ui to rerender, still weird that only happens the first time.

--- a/moxin-frontend/src/chat/chat_line.rs
+++ b/moxin-frontend/src/chat/chat_line.rs
@@ -6,8 +6,8 @@ live_design! {
 
     import makepad_draw::shader::std::*;
     import crate::shared::styles::*;
+    import crate::shared::resource_imports::*;
 
-    ICON_COPY = dep("crate://self/resources/icons/copy.svg")
     ICON_EDIT = dep("crate://self/resources/icons/edit.svg")
     ICON_DELETE = dep("crate://self/resources/icons/delete.svg")
 

--- a/moxin-frontend/src/landing/model_card.rs
+++ b/moxin-frontend/src/landing/model_card.rs
@@ -1,6 +1,7 @@
 use crate::data::store::{ModelWithPendingDownloads, Store};
 use crate::shared::external_link::ExternalLinkWidgetExt;
 use crate::shared::modal::ModalAction;
+use crate::shared::utils::hugging_face_model_url;
 use makepad_widgets::*;
 use moxin_protocol::data::ModelID;
 use unicode_segmentation::UnicodeSegmentation;
@@ -383,8 +384,7 @@ impl Widget for ModelCard {
             .set_text(author_name);
         author_external_link.set_url(author_url);
 
-        let hugging_face_base_url = "https://huggingface.co";
-        let model_hugging_face_url = hugging_face_base_url.to_owned() + "/" + &model.id;
+        let model_hugging_face_url = hugging_face_model_url(&model.id);
         let mut model_hugging_face_external_link = self.external_link(id!(model_hugging_face_link));
         model_hugging_face_external_link.set_url(&model_hugging_face_url);
 

--- a/moxin-frontend/src/my_models/delete_model_modal.rs
+++ b/moxin-frontend/src/my_models/delete_model_modal.rs
@@ -17,7 +17,7 @@ live_design! {
 
         wrapper = <RoundedView> {
             flow: Down
-            width: 500
+            width: 600
             height: Fit
             padding: {top: 50, right: 30 bottom: 30 left: 50}
             spacing: 10
@@ -77,7 +77,7 @@ live_design! {
                     width: Fill
                     draw_text: {
                         text_style: <REGULAR_FONT>{
-                            font_size: 10,
+                            font_size: 13,
                             height_factor: 1.3
                         },
                         color: #000
@@ -107,7 +107,7 @@ live_design! {
                         <Label> {
                             text: "Cancel"
                             draw_text:{
-                                text_style: <BOLD_FONT>{font_size: 10},
+                                text_style: <REGULAR_FONT>{font_size: 13},
                                 color: #x0
                             }
                         }
@@ -126,7 +126,7 @@ live_design! {
                         <Label> {
                             text: "Delete"
                             draw_text:{
-                                text_style: <BOLD_FONT>{font_size: 10},
+                                text_style: <REGULAR_FONT>{font_size: 13},
                                 color: #fff
                             }
                         }

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -8,7 +8,7 @@ use crate::{
     shared::{modal::ModalAction, utils::format_model_size},
 };
 
-use super::delete_model_modal::DeleteModelAction;
+use super::{delete_model_modal::DeleteModelAction, model_info_modal::ModelInfoAction};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -331,7 +331,18 @@ impl WidgetMatchEvent for DownloadedFilesTable {
                             }
                         }
                         RowAction::InfoClicked => {
-                            if let Some(_item_id) = self.file_item_map.get(&action.widget_uid.0) {}
+                            if let Some(item_id) = self.file_item_map.get(&group.item_uid.0) {
+                                cx.widget_action(
+                                    widget_uid,
+                                    &scope.path,
+                                    ModelInfoAction::FileSelected(item_id.clone()),
+                                );
+                                cx.widget_action(
+                                    widget_uid,
+                                    &scope.path,
+                                    ModalAction::ShowModalView(live_id!(model_info_modal_view)),
+                                );
+                            }
                         }
                         RowAction::DeleteClicked => {
                             if let Some(item_id) = self.file_item_map.get(&group.item_uid.0) {

--- a/moxin-frontend/src/my_models/mod.rs
+++ b/moxin-frontend/src/my_models/mod.rs
@@ -1,3 +1,4 @@
 pub mod delete_model_modal;
 pub mod downloaded_files_table;
+pub mod model_info_modal;
 pub mod my_models_screen;

--- a/moxin-frontend/src/my_models/model_info_modal.rs
+++ b/moxin-frontend/src/my_models/model_info_modal.rs
@@ -18,9 +18,8 @@ live_design! {
         draw_block: {
             code_color: (#EAECF0)
         }
-        list_item_layout: { line_spacing: (5.0), padding: {left: 5.0, top: 1.0, bottom: 1.0}, }
+        font_size: 12
         code_layout: { line_spacing: (5.0), padding: 15, }
-        quote_layout: { line_spacing: (5.0), padding: {top: 0.0, bottom: 8.0}, }
     }
 
     ModelInfoModal = {{ModelInfoModal}} {
@@ -32,7 +31,7 @@ live_design! {
             width: 800
             height: Fit
             padding: {top: 50, right: 30 bottom: 30 left: 50}
-            spacing: 10
+            spacing: 5
 
             show_bg: true
             draw_bg: {
@@ -82,19 +81,20 @@ live_design! {
                 width: Fill,
                 height: Fit,
                 flow: Right,
-                spacing: 10
+                spacing: 8
                 // Hack to align the text with the html block, 0.5 it not visually centered
                 align: {x: 0.0, y: 0.6}
 
                 <Label> {
                     text: "Read from"
                     draw_text: {
-                        text_style: <BOLD_FONT>{font_size: 13},
+                        text_style: <REGULAR_FONT>{font_size: 13},
                         color: #344054
                     }
                 }
                 path = <MoxinHtml> {
                     width: Fill
+                    font_size: 11
                     code_layout: { line_spacing: (5.0), padding: 9 }
                 }
             }

--- a/moxin-frontend/src/my_models/model_info_modal.rs
+++ b/moxin-frontend/src/my_models/model_info_modal.rs
@@ -1,0 +1,272 @@
+use crate::{
+    data::store::Store,
+    shared::{modal::ModalAction, utils::hugging_face_model_url},
+};
+use makepad_widgets::*;
+use moxin_protocol::data::ModelID;
+
+live_design! {
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+    import makepad_draw::shader::std::*;
+
+    import crate::shared::styles::*;
+    import crate::shared::resource_imports::*;
+
+    MoxinHtml = <Html> {
+        draw_fixed: { color: #x0 }
+        draw_block: {
+            code_color: (#EAECF0)
+        }
+        list_item_layout: { line_spacing: (5.0), padding: {left: 5.0, top: 1.0, bottom: 1.0}, }
+        code_layout: { line_spacing: (5.0), padding: 15, }
+        quote_layout: { line_spacing: (5.0), padding: {top: 0.0, bottom: 8.0}, }
+    }
+
+    ModelInfoModal = {{ModelInfoModal}} {
+        width: Fit
+        height: Fit
+
+        wrapper = <RoundedView> {
+            flow: Down
+            width: 800
+            height: Fit
+            padding: {top: 50, right: 30 bottom: 30 left: 50}
+            spacing: 10
+
+            show_bg: true
+            draw_bg: {
+                color: #fff
+                radius: 3
+            }
+
+            <View> {
+                width: Fill,
+                height: Fit,
+                flow: Right
+
+                title = <View> {
+                    width: Fit,
+                    height: Fit,
+                    padding: {bottom: 20}
+
+                    filename = <Label> {
+                        draw_text: {
+                            text_style: <BOLD_FONT>{font_size: 15},
+                            color: #000
+                        }
+                    }
+                }
+
+                filler_x = <View> {width: Fill, height: Fit}
+
+                close_button = <RoundedView> {
+                    width: Fit,
+                    height: Fit,
+                    align: {x: 0.5, y: 0.5}
+                    cursor: Hand
+
+                    button_icon = <Icon> {
+                        draw_icon: {
+                            svg_file: (ICON_CLOSE),
+                            fn get_color(self) -> vec4 {
+                                return #000;
+                            }
+                        }
+                        icon_walk: {width: 12, height: 12}
+                    }
+                }
+            }
+
+            file_dir = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Right,
+                spacing: 10
+                // Hack to align the text with the html block, 0.5 it not visually centered
+                align: {x: 0.0, y: 0.6}
+
+                <Label> {
+                    text: "Read from"
+                    draw_text: {
+                        text_style: <BOLD_FONT>{font_size: 13},
+                        color: #344054
+                    }
+                }
+                path = <MoxinHtml> {
+                    width: Fill
+                    code_layout: { line_spacing: (5.0), padding: 9 }
+                }
+            }
+
+            body = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Down,
+                spacing: 20,
+
+                metadata = <MoxinHtml> {}
+                actions = <View> {
+                    width: Fill, height: Fit
+                    flow: Right,
+                    align: {x: 0.0, y: 0.5}
+                    spacing: 20
+
+                    copy_button = <RoundedView> {
+                        width: Fit,
+                        height: Fit,
+                        padding: {top: 10, bottom: 10, left: 14, right: 14}
+                        cursor: Hand
+                        flow: Right,
+                        spacing: 10
+
+                        icon = <Icon> {
+                            draw_icon: {
+                                svg_file: (ICON_COPY)
+                                fn get_color(self) -> vec4 {
+                                    return #x0;
+                                }
+                            }
+                            icon_walk: {width: 14, height: 14}
+                        }
+
+                        draw_bg: {
+                            instance radius: 2.0,
+                            border_color: #D0D5DD,
+                            border_width: 1.2,
+                            color: #EDFCF2,
+                        }
+
+                        <Label> {
+                            text: "Copy to Clipboard"
+                            draw_text:{
+                                text_style: <REGULAR_FONT>{font_size: 13},
+                                color: #x0
+                            }
+                        }
+                    }
+                    external_link = <RoundedView> {
+                        width: Fit,
+                        height: Fit,
+                        padding: {top: 10, bottom: 10, left: 14, right: 14}
+                        cursor: Hand
+
+                        draw_bg: {
+                            instance radius: 2.0,
+                            border_color: #D0D5DD,
+                            border_width: 1.2,
+                            color: #F5FEFF,
+                        }
+
+                        <Label> {
+                            text: "Model Card on Hugging Face"
+                            draw_text:{
+                                text_style: <REGULAR_FONT>{font_size: 13},
+                                color: #x0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ModelInfoModal {
+    #[deref]
+    view: View,
+    #[rust]
+    file_id: String,
+    #[rust]
+    model_id: String,
+    #[rust]
+    stringified_model_data: String,
+}
+
+impl Widget for ModelInfoModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let downloaded_files = &scope.data.get::<Store>().unwrap().downloaded_files;
+        let downloaded_file = downloaded_files
+            .iter()
+            .find(|f| f.file.id.eq(&self.file_id))
+            .expect("Downloaded file not found");
+
+        self.model_id = downloaded_file.model.id.clone();
+
+        // filename
+        self.label(id!(title.filename))
+            .set_text(&downloaded_file.file.name);
+
+        // file path
+        if let Some(path) = &downloaded_file.file.downloaded_path {
+            self.html(id!(file_dir.path))
+                .set_text(&format!("<pre>{}</pre>", path));
+        } else {
+            self.view(id!(file_dir)).set_visible(false);
+        }
+
+        // metadata
+        self.stringified_model_data = serde_json::to_string_pretty(&downloaded_file.model)
+            .expect("Could not serialize model data into json");
+        let metadata = format!("<pre>{}</pre>", self.stringified_model_data);
+
+        self.html(id!(wrapper.body.metadata)).set_text(&metadata);
+
+        self.view
+            .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))
+    }
+}
+
+impl WidgetMatchEvent for ModelInfoModal {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        let widget_uid = self.widget_uid();
+
+        if let Some(fe) = self.view(id!(close_button)).finger_up(actions) {
+            if fe.was_tap() {
+                cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
+            }
+        }
+
+        if let Some(fe) = self
+            .view(id!(wrapper.body.actions.copy_button))
+            .finger_up(actions)
+        {
+            if fe.was_tap() {
+                // TODO
+                // cx.copy_to_clipboard(&self.stringified_model_data);
+            }
+        }
+
+        if let Some(fe) = self
+            .view(id!(wrapper.body.actions.external_link))
+            .finger_up(actions)
+        {
+            if fe.was_tap() {
+                let model_url = hugging_face_model_url(&self.model_id);
+                if let Err(e) = robius_open::Uri::new(&model_url).open() {
+                    error!("Error opening URL: {:?}", e);
+                }
+            }
+        }
+    }
+}
+
+impl ModelInfoModalRef {
+    pub fn set_file_id(&mut self, file_id: ModelID) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.file_id = file_id;
+        }
+    }
+}
+
+#[derive(Clone, DefaultNone, Debug)]
+pub enum ModelInfoAction {
+    FileSelected(String),
+    None,
+}

--- a/moxin-frontend/src/shared/resource_imports.rs
+++ b/moxin-frontend/src/shared/resource_imports.rs
@@ -2,4 +2,5 @@ use makepad_widgets::*;
 
 live_design! {
     ICON_CLOSE = dep("crate://self/resources/icons/close.svg")
+    ICON_COPY = dep("crate://self/resources/icons/copy.svg")
 }

--- a/moxin-frontend/src/shared/utils.rs
+++ b/moxin-frontend/src/shared/utils.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 pub const BYTES_PER_MB: f64 = 1_048_576.0; // (1024^2)
+pub const HUGGING_FACE_BASE_URL: &str = "https://huggingface.co";
 
 pub fn format_model_size(size: &str) -> Result<String> {
     let size_mb = size.parse::<f64>()? / BYTES_PER_MB;
@@ -20,4 +21,8 @@ pub fn format_model_downloaded_size(size: &str, progress: f64) -> Result<String>
     } else {
         Ok(format!("{:.2} MB", size_mb as i32))
     }
+}
+
+pub fn hugging_face_model_url(model_id: &str) -> String {
+    format!("{}/{}", HUGGING_FACE_BASE_URL, model_id)
 }


### PR DESCRIPTION
Adds the info modal to My Models view

Does not yet implement the copy to clipboard action, since that requires some support from Makepad.


https://github.com/project-robius/moxin/assets/22042418/9321e897-e300-4a72-b282-5f8efdb86e4a

