### PR TITLE
Regenerate chat option

### DIFF
--- a/moxin-frontend/src/chat/chat_line.rs
+++ b/moxin-frontend/src/chat/chat_line.rs
@@ -37,6 +37,13 @@ live_design! {
         }
     }
 
+    SaveAndRegerateButton = <ChatLineEditButton> {
+        width: 130,
+        button_label = {
+            text: "Save & Regenerate"
+        }
+    }
+
     CancelButton = <ChatLineEditButton> {
         draw_bg: { border_color: #D0D5DD, border_width: 1.0, color: #fff }
 
@@ -150,6 +157,7 @@ live_design! {
                 margin: {top: 10},
                 spacing: 6,
                 save = <SaveButton> {}
+                save_and_regenerate = <SaveAndRegerateButton> {}
                 cancel = <CancelButton> {}
             }
         }
@@ -224,7 +232,7 @@ live_design! {
 #[derive(Clone, DefaultNone, Debug)]
 pub enum ChatLineAction {
     Delete(usize),
-    Edit(usize, String),
+    Edit(usize, String, bool),
     Copy(usize),
     None,
 }
@@ -333,7 +341,22 @@ impl ChatLine {
                 cx.widget_action(
                     widget_id,
                     &scope.path,
-                    ChatLineAction::Edit(self.message_id, updated_message),
+                    ChatLineAction::Edit(self.message_id, updated_message, false),
+                );
+
+                self.set_edit_mode(cx, false);
+            }
+        }
+
+        if let Some(fe) = self.view(id!(save_and_regenerate)).finger_up(&actions) {
+            if fe.was_tap() {
+                let updated_message = self.text_input(id!(input)).text();
+
+                let widget_id = self.view.widget_uid();
+                cx.widget_action(
+                    widget_id,
+                    &scope.path,
+                    ChatLineAction::Edit(self.message_id, updated_message, true),
                 );
 
                 self.set_edit_mode(cx, false);
@@ -396,5 +419,12 @@ impl ChatLineRef {
             inner.edition_state = ChatLineState::NotEditable;
             inner.view(id!(actions_section.actions)).set_visible(false);
         }
+    }
+
+    pub fn set_regenerate_enabled(&mut self, enabled: bool) {
+        let Some(mut inner) = self.borrow_mut() else {
+            return;
+        };
+        inner.view(id!(save_and_regenerate)).set_visible(enabled);
     }
 }

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -404,11 +404,13 @@ impl Widget for ChatPanel {
                             item = list.item(cx, item_id, live_id!(ModelChatLine)).unwrap();
                             chat_line_item = item.as_chat_line();
                             chat_line_item.set_role(&model_filename);
+                            chat_line_item.set_regenerate_enabled(false);
                             chat_line_item.set_avatar_text(&initial_letter);
                         } else {
                             item = list.item(cx, item_id, live_id!(UserChatLine)).unwrap();
                             chat_line_item = item.as_chat_line();
                             chat_line_item.set_role("You");
+                            chat_line_item.set_regenerate_enabled(true);
                         };
 
                         chat_line_item.set_message_text(&chat_line_data.content);
@@ -458,9 +460,9 @@ impl WidgetMatchEvent for ChatPanel {
                     store.delete_chat_message(id);
                     self.redraw(cx);
                 }
-                ChatLineAction::Edit(id, updated) => {
+                ChatLineAction::Edit(id, updated, regenerate) => {
                     let store = scope.data.get_mut::<Store>().unwrap();
-                    store.edit_chat_message(id, updated);
+                    store.edit_chat_message(id, updated, regenerate);
                     self.redraw(cx);
                 }
                 _ => {}

--- a/moxin-frontend/src/data/chat.rs
+++ b/moxin-frontend/src/data/chat.rs
@@ -159,4 +159,9 @@ impl Chat {
             message.content = updated_message;
         }
     }
+
+    pub fn remove_messages_from(&mut self, message_id: usize) {
+        let message_index = self.messages.iter().position(|m| m.id == message_id).unwrap();
+        self.messages.truncate(message_index);
+    }
 }

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -250,9 +250,18 @@ impl Store {
         }
     }
 
-    pub fn edit_chat_message(&mut self, message_id: usize, updated_message: String) {
+    pub fn edit_chat_message(&mut self, message_id: usize, updated_message: String, regenerate: bool) {
         if let Some(chat) = &mut self.current_chat {
-            chat.edit_message(message_id, updated_message);
+            if regenerate {
+                if chat.is_streaming {
+                    chat.cancel_streaming(&self.backend);
+                }
+
+                chat.remove_messages_from(message_id);
+                chat.send_message_to_model(updated_message, &self.backend);
+            } else {
+                chat.edit_message(message_id, updated_message);
+            }
         }
     }
 


### PR DESCRIPTION
There is now an option to regenerate the conversation upon editing a user prompt.

<img width="862" alt="image" src="https://github.com/project-robius/moxin/assets/487140/d9925c1c-c41f-4405-977b-b3d625589465">

TBD: Final design of the option will be checked by design team.
