### PR TITLE
Centralize local files in a home directory

### DIFF
--- a/moxin-backend/src/backend_impls.rs
+++ b/moxin-backend/src/backend_impls.rs
@@ -849,7 +849,7 @@ impl BackendImpl {
     ) -> Sender<Command> {
         wasmedge_sdk::plugin::PluginManager::load(None).unwrap();
 
-        let sql_conn = rusqlite::Connection::open(format!("{home_dir}/data.sql")).unwrap();
+        let sql_conn = rusqlite::Connection::open(format!("{home_dir}/data.sqlite")).unwrap();
 
         // TODO Reorganize these bunch of functions, needs a little more of thought
         let _ = store::models::create_table_models(&sql_conn).unwrap();

--- a/moxin-frontend/src/data/filesystem.rs
+++ b/moxin-frontend/src/data/filesystem.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+use std::{env, fs};
+
+// Note that .moxin will create a hidden folder in unix-like systems.
+// However in Windows the folder will be visible by default.
+pub const DEFAULT_DOWNLOADS_DIR: &str = ".moxin/model_downloads";
+pub const MOXIN_HOME_DIR: &str = ".moxin";
+
+pub fn setup_model_downloads_folder() -> String {
+    let home_dir = get_home_dir();
+    let downloads_dir = PathBuf::from(home_dir).join(DEFAULT_DOWNLOADS_DIR);
+
+    if fs::create_dir_all(&downloads_dir).is_err() {
+        eprintln!(
+            "Failed to create the model downloads directory at '{}'. Using current directory as fallback.",
+            downloads_dir.display()
+        );
+        ".".to_string()
+    } else {
+        downloads_dir.to_string_lossy().to_string()
+    }
+}
+
+pub fn get_home_dir() -> String {
+    env::var("HOME"). // Unix-like systems
+        or_else(|_| env::var("USERPROFILE")) // Windows
+        .unwrap_or_else(|_| ".".to_string())
+}
+
+pub fn moxin_home_dir() -> PathBuf {
+    let home_dir = get_home_dir();
+    PathBuf::from(home_dir).join(MOXIN_HOME_DIR)
+}

--- a/moxin-frontend/src/data/filesystem.rs
+++ b/moxin-frontend/src/data/filesystem.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
+use std::process::Command;
 use std::{env, fs};
+
+use anyhow::{Context, Result};
 
 // Note that .moxin will create a hidden folder in unix-like systems.
 // However in Windows the folder will be visible by default.
@@ -30,4 +33,19 @@ pub fn get_home_dir() -> String {
 pub fn moxin_home_dir() -> PathBuf {
     let home_dir = get_home_dir();
     PathBuf::from(home_dir).join(MOXIN_HOME_DIR)
+}
+
+pub fn open_folder(path: &str) -> Result<()> {
+    let result = if cfg!(target_os = "windows") {
+        Command::new("explorer").arg(path).spawn()
+    } else if cfg!(target_os = "macos") {
+        Command::new("open").arg(path).spawn()
+    } else {
+        // Assuming xdg-open is available for Linux and Unix-like systems
+        Command::new("xdg-open").arg(path).spawn()
+    };
+
+    result.context(format!("Failed to open folder: {}", path))?;
+
+    Ok(())
 }

--- a/moxin-frontend/src/data/mod.rs
+++ b/moxin-frontend/src/data/mod.rs
@@ -1,5 +1,6 @@
 pub mod chat;
 pub mod download;
+pub mod filesystem;
 pub mod preferences;
 pub mod search;
 pub mod store;

--- a/moxin-frontend/src/data/preferences.rs
+++ b/moxin-frontend/src/data/preferences.rs
@@ -1,11 +1,14 @@
 use std::{
     fs::File,
     io::{Read, Write},
-    path::Path,
+    path::PathBuf,
 };
 
 use moxin_protocol::data::FileID;
 use serde::{Deserialize, Serialize};
+
+use super::filesystem::moxin_home_dir;
+const PREFERENCES_FILE: &str = "preferences.json";
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Preferences {
@@ -39,7 +42,7 @@ impl Preferences {
 }
 
 fn read_from_file() -> Result<String, std::io::Error> {
-    let path = Path::new("preferences.json");
+    let path = preferences_path();
 
     let mut file = match File::open(&path) {
         Ok(file) => file,
@@ -54,7 +57,7 @@ fn read_from_file() -> Result<String, std::io::Error> {
 }
 
 fn write_to_file(json: &str) -> Result<(), std::io::Error> {
-    let path = Path::new("preferences.json");
+    let path = preferences_path();
 
     let mut file = match File::create(&path) {
         Ok(file) => file,
@@ -65,4 +68,10 @@ fn write_to_file(json: &str) -> Result<(), std::io::Error> {
         Ok(_) => Ok(()),
         Err(why) => Err(why),
     }
+}
+
+fn preferences_path() -> PathBuf {
+    let home_dir = moxin_home_dir();
+    let preferences_path = PathBuf::from(home_dir).join(PREFERENCES_FILE);
+    preferences_path
 }

--- a/moxin-frontend/src/my_models/my_models_screen.rs
+++ b/moxin-frontend/src/my_models/my_models_screen.rs
@@ -1,10 +1,7 @@
 use makepad_widgets::*;
 use moxin_protocol::data::DownloadedFile;
 
-use crate::{
-    data::store::Store,
-    shared::utils::{open_folder, BYTES_PER_MB},
-};
+use crate::{data::filesystem::open_folder, data::store::Store, shared::utils::BYTES_PER_MB};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -205,7 +202,7 @@ pub struct MyModelsScreen {
 impl Widget for MyModelsScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
-        self.match_event(cx, event);
+        self.widget_match_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
@@ -233,12 +230,17 @@ fn file_manager_label() -> String {
     }
 }
 
-impl MatchEvent for MyModelsScreen {
-    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+impl WidgetMatchEvent for MyModelsScreen {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         if let Some(fe) = self.view(id!(show_in_files)).finger_up(actions) {
             if fe.was_tap() {
-                // TODO: replace with actual downloads path in the current store.
-                open_folder(".").expect("Failed to open downloads folder");
+                let models_dir = &scope.data.get::<Store>().unwrap().downloaded_files_dir;
+                open_folder(models_dir).unwrap_or_else(|e| {
+                    println!(
+                        "Failed to open models downloads folder: {}. Check for permissions.",
+                        e
+                    );
+                });
             }
         }
 

--- a/moxin-frontend/src/shared/utils.rs
+++ b/moxin-frontend/src/shared/utils.rs
@@ -1,5 +1,4 @@
-use anyhow::{Context, Result};
-use std::process::Command;
+use anyhow::Result;
 
 pub const BYTES_PER_MB: f64 = 1_048_576.0; // (1024^2)
 pub const HUGGING_FACE_BASE_URL: &str = "https://huggingface.co";
@@ -26,20 +25,4 @@ pub fn format_model_downloaded_size(size: &str, progress: f64) -> Result<String>
 
 pub fn hugging_face_model_url(model_id: &str) -> String {
     format!("{}/{}", HUGGING_FACE_BASE_URL, model_id)
-}
-
-pub fn open_folder(path: &str) -> Result<()> {
-    let result = if cfg!(target_os = "windows") {
-        Command::new("explorer").arg(path).spawn()
-    } else if cfg!(target_os = "macos") {
-        Command::new("open").arg(path).spawn()
-    } else {
-        // Defaulting to Linux and other Unix-like OS,
-        // this assumes that 'xdg-open' is available.
-        Command::new("xdg-open").arg(path).spawn()
-    };
-
-    result.context(format!("Failed to open folder: {}", path))?;
-
-    Ok(())
 }


### PR DESCRIPTION
Updates filesystem usage:

- Store database, preferences.json and downloaded models under the users home directory, e.g. 
`$HOME/.moxin` for macOS

- Stores downloads path in store to use in 'Review in FInder'

- Renames `data.db` to `data.sqlite`