### PR TITLE
Implement delete model file

### DIFF
--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -446,12 +446,11 @@ impl WidgetMatchEvent for ChatPanel {
                     if store
                         .current_chat
                         .as_ref()
-                        .map_or(false, |chat| chat.model_filename == file_id)
+                        .map_or(false, |chat| chat.file_id == file_id)
                     {
                         self.unload_model(cx);
                         store.current_chat = None;
                         store.eject_model().expect("Failed to eject model");
-                        log!("UNLOADING");
                     }
                 }
                 _ => {}

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -1,6 +1,6 @@
 use crate::{
-    data::store::Store, my_models::downloaded_files_table::DownloadedFileAction,
-    shared::utils::format_model_size,
+    data::store::Store,
+    my_models::downloaded_files_table::DownloadedFileAction, shared::utils::format_model_size,
 };
 use makepad_widgets::*;
 use moxin_protocol::data::DownloadedFile;
@@ -317,6 +317,32 @@ impl ModelSelector {
             },
         );
         self.redraw(cx);
+    }
+
+    fn deselect(&mut self, cx: &mut Cx) {
+        self.open = false;
+        self.view(id!(selected)).apply_over(
+            cx,
+            live! {
+                visible: false
+            },
+        );
+
+        self.view(id!(choose)).apply_over(
+            cx,
+            live! {
+                visible: true
+            },
+        );
+        self.redraw(cx);
+    }
+}
+
+impl ModelSelectorRef {
+    pub fn deselect(&mut self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.deselect(cx);
+        }
     }
 }
 

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -1,6 +1,6 @@
 use crate::{
-    data::store::Store,
-    my_models::downloaded_files_table::DownloadedFileAction, shared::utils::format_model_size,
+    data::store::Store, my_models::downloaded_files_table::DownloadedFileAction,
+    shared::utils::format_model_size,
 };
 use makepad_widgets::*;
 use moxin_protocol::data::DownloadedFile;
@@ -257,7 +257,6 @@ impl WidgetMatchEvent for ModelSelector {
             let store = scope.data.get_mut::<Store>().unwrap();
             match action.as_widget_action().cast() {
                 ModelSelectorAction::Selected(downloaded_file) => {
-                    store.active_chat_file = Some(downloaded_file.file.id.clone());
                     self.update_ui_with_file(cx, downloaded_file);
                 }
                 _ => {}
@@ -265,7 +264,6 @@ impl WidgetMatchEvent for ModelSelector {
 
             match action.as_widget_action().cast() {
                 DownloadedFileAction::StartChat(file_id) => {
-                    store.active_chat_file = Some(file_id.clone());
                     let downloaded_file = store
                         .downloaded_files
                         .iter()

--- a/moxin-frontend/src/data/chat.rs
+++ b/moxin-frontend/src/data/chat.rs
@@ -1,5 +1,6 @@
 use makepad_widgets::SignalToUI;
 use moxin_backend::Backend;
+use moxin_protocol::data::FileID;
 use moxin_protocol::open_ai::*;
 use moxin_protocol::protocol::Command;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -25,6 +26,7 @@ impl ChatMessage {
 
 pub struct Chat {
     pub model_filename: String,
+    pub file_id: FileID,
     pub messages: Vec<ChatMessage>,
     pub messages_update_sender: Sender<ChatTokenArrivalAction>,
     pub messages_update_receiver: Receiver<ChatTokenArrivalAction>,
@@ -32,10 +34,11 @@ pub struct Chat {
 }
 
 impl Chat {
-    pub fn new(filename: String) -> Self {
+    pub fn new(filename: String, file_id: FileID) -> Self {
         let (tx, rx) = channel();
         let chat = Self {
             model_filename: filename,
+            file_id,
             messages: vec![],
             messages_update_sender: tx,
             messages_update_receiver: rx,

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -71,8 +71,6 @@ pub struct Store {
 
     pub preferences: Preferences,
     pub downloaded_files_dir: String,
-
-    pub active_chat_file: Option<FileID>,
 }
 
 impl Store {
@@ -102,8 +100,6 @@ impl Store {
 
             preferences: Preferences::load(),
             downloaded_files_dir,
-
-            active_chat_file: None,
         };
         store.load_downloaded_files();
         store.load_pending_downloads();
@@ -272,7 +268,7 @@ impl Store {
                         eprintln!("Error loading model");
                         return;
                     };
-                    self.current_chat = Some(Chat::new(file.name.clone()));
+                    self.current_chat = Some(Chat::new(file.name.clone(), file.id.clone()));
                     self.preferences.set_current_chat_model(file.id.clone());
                 }
                 Err(err) => eprintln!("Error loading model: {:?}", err),

--- a/moxin-frontend/src/my_models/delete_model_modal.rs
+++ b/moxin-frontend/src/my_models/delete_model_modal.rs
@@ -1,7 +1,7 @@
 use makepad_widgets::*;
 use moxin_protocol::data::ModelID;
 
-use crate::{data::store::Store, shared::modal::ModalAction};
+use crate::{chat::chat_panel::ChatPanelAction, data::store::Store, shared::modal::ModalAction};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -187,7 +187,12 @@ impl WidgetMatchEvent for DeleteModelModal {
         {
             if fe.was_tap() {
                 let store = scope.data.get_mut::<Store>().unwrap();
-                store.delete_file(self.file_id.clone());
+                cx.widget_action(
+                    widget_uid,
+                    &scope.path,
+                    ChatPanelAction::UnloadIfActive(self.file_id.clone()),
+                );
+                store.delete_file(self.file_id.clone()).expect("Failed to delete file");
                 cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
             }
         }

--- a/moxin-frontend/src/my_models/delete_model_modal.rs
+++ b/moxin-frontend/src/my_models/delete_model_modal.rs
@@ -192,7 +192,9 @@ impl WidgetMatchEvent for DeleteModelModal {
                     &scope.path,
                     ChatPanelAction::UnloadIfActive(self.file_id.clone()),
                 );
-                store.delete_file(self.file_id.clone()).expect("Failed to delete file");
+                store
+                    .delete_file(self.file_id.clone())
+                    .expect("Failed to delete file");
                 cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
             }
         }

--- a/moxin-frontend/src/my_models/delete_model_modal.rs
+++ b/moxin-frontend/src/my_models/delete_model_modal.rs
@@ -182,6 +182,17 @@ impl WidgetMatchEvent for DeleteModelModal {
         }
 
         if let Some(fe) = self
+            .view(id!(wrapper.body.actions.delete_button))
+            .finger_up(actions)
+        {
+            if fe.was_tap() {
+                let store = scope.data.get_mut::<Store>().unwrap();
+                store.delete_file(self.file_id.clone());
+                cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
+            }
+        }
+
+        if let Some(fe) = self
             .view(id!(wrapper.body.actions.cancel_button))
             .finger_up(actions)
         {

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -287,7 +287,10 @@ impl Widget for DownloadedFilesTable {
         let entries_count = self.current_results.len();
         let last_item_id = if entries_count > 0 { entries_count } else { 0 };
 
-        let active_chat_file_id = scope.data.get::<Store>().unwrap().active_chat_file.clone();
+        let mut current_chat_file_id = None;
+        if let Some(current_chat) = &scope.data.get::<Store>().unwrap().current_chat {
+            current_chat_file_id = Some(current_chat.file_id.clone());
+        }
 
         while let Some(item) = self.view.draw_walk(cx, scope, walk).step() {
             if let Some(mut list) = item.as_portal_list().borrow_mut() {
@@ -350,19 +353,25 @@ impl Widget for DownloadedFilesTable {
                         item.label(id!(h_wrapper.date_added_tag.date_added))
                             .set_text(&formatted_date);
 
+                        // Wether to show show a start chat or resume chat button
                         let mut start_chat_button =
                             item.action_button(id!(h_wrapper.actions.start_chat));
                         let mut resume_chat_button =
                             item.action_button(id!(h_wrapper.actions.resume_chat));
+                        let mut show_resume_button = false;
 
-                        if let Some(file_id) = &active_chat_file_id {
+                        if let Some(file_id) = &current_chat_file_id {
                             if *file_id == file_data.file.id {
-                                start_chat_button.set_visible(false);
-                                resume_chat_button.set_visible(true);
-                            } else {
-                                start_chat_button.set_visible(true);
-                                resume_chat_button.set_visible(false);
+                                show_resume_button = true;
                             }
+                        }
+
+                        if show_resume_button {
+                            resume_chat_button.set_visible(true);
+                            start_chat_button.set_visible(false);
+                        } else {
+                            start_chat_button.set_visible(true);
+                            resume_chat_button.set_visible(false);
                         }
 
                         // Don't draw separator line on first row

--- a/moxin-protocol/src/protocol.rs
+++ b/moxin-protocol/src/protocol.rs
@@ -84,6 +84,7 @@ pub enum Command {
     DownloadFile(FileID, Sender<Result<FileDownloadResponse>>),
     PauseDownload(FileID, Sender<Result<()>>),
     CancelDownload(FileID, Sender<Result<()>>),
+    DeleteFile(FileID, Sender<Result<()>>),
 
     GetCurrentDownloads(Sender<Result<Vec<PendingDownload>>>),
     GetDownloadedFiles(Sender<Result<Vec<DownloadedFile>>>),


### PR DESCRIPTION
Implements the file deletion in the My Models table. 

Automatically refreshes state int he landing screen files.

If the model is actively loaded it will be ejected, and the chat panel will be reset.

https://github.com/project-robius/moxin/assets/22042418/53720c82-e8c7-4532-b0c4-e22011af8c17

