### PR TITLE
Redesign chat screen when there are no downloaded models

### DIFF
--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -1,3 +1,4 @@
+use crate::chat::chat_panel::ChatPanelAction;
 use crate::data::store::*;
 use crate::landing::download_item::DownloadItemAction;
 use crate::landing::model_card::{ModelCardViewAllModalWidgetRefExt, ViewAllModalAction};
@@ -300,6 +301,11 @@ impl MatchEvent for App {
             if let PopupAction::NavigateToMyModels = action.as_widget_action().cast() {
                 let my_models_radio_button = self.ui.radio_button(id!(my_models_tab));
                 my_models_radio_button.select(cx, &mut Scope::empty());
+            }
+
+            if let ChatPanelAction::NavigateToDiscover = action.as_widget_action().cast() {
+                let discover_radio_button = self.ui.radio_button(id!(discover_tab));
+                discover_radio_button.select(cx, &mut Scope::empty());
             }
 
             if let DownloadedFileAction::ResumeChat(_) = action.as_widget_action().cast() {

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -237,7 +237,7 @@ live_design! {
                 width: Fill, height: Fit
                 flow: Down,
                 align: {x: 0.5, y: 0.5},
-                chat_input = <ChatPromptInput> {}
+                no_downloaded_model_prompt_input = <ChatPromptInput> {}
             }
 
         }
@@ -277,7 +277,7 @@ live_design! {
                 width: Fill, height: Fit
                 flow: Down,
                 align: {x: 0.5, y: 0.5},
-                chat_input = <ChatPromptInput> {}
+                no_model_prompt_input = <ChatPromptInput> {}
             }
 
         }
@@ -331,7 +331,7 @@ live_design! {
                 <JumpToButtom> {}
             }
 
-            <ChatPromptInput> {}
+            main_prompt_input = <ChatPromptInput> {}
         }
 
         model_selector = <ModelSelector> {}
@@ -624,7 +624,7 @@ impl ChatPanel {
                 auto_scroll_pending: _,
                 auto_scroll_cancellable: _,
             } => {
-                let prompt_input = self.text_input(id!(prompt));
+                let prompt_input = self.text_input(id!(main_prompt_input.prompt));
                 prompt_input.apply_over(
                     cx,
                     live! {
@@ -640,7 +640,7 @@ impl ChatPanel {
     }
 
     fn enable_or_disable_prompt_input(&mut self, cx: &mut Cx) {
-        let prompt_input = self.text_input(id!(prompt));
+        let prompt_input = self.text_input(id!(main_prompt_input.prompt));
         let enable = if prompt_input.text().len() > 0 {
             1.0
         } else {
@@ -753,7 +753,7 @@ impl ChatPanel {
     }
 
     fn handle_prompt_input_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        let prompt_input = self.text_input(id!(prompt));
+        let prompt_input = self.text_input(id!(main_prompt_input.prompt));
 
         if let Some(_text) = prompt_input.changed(actions) {
             self.update_prompt_input(cx);
@@ -779,7 +779,7 @@ impl ChatPanel {
         let store = scope.data.get_mut::<Store>().unwrap();
         store.send_chat_message(prompt.clone());
 
-        let prompt_input = self.text_input(id!(prompt));
+        let prompt_input = self.text_input(id!(main_prompt_input.prompt));
         prompt_input.set_text_and_redraw(cx, "");
         prompt_input.set_cursor(0, 0);
         self.update_prompt_input(cx);

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -227,7 +227,6 @@ live_design! {
                 width: Fill, height: Fit
                 flow: Down,
                 align: {x: 0.5, y: 0.5},
-                filler = <View> { width: Fill, height: Fill }
                 chat_input = <ChatPromptInput> {}
             }
 

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -197,23 +197,40 @@ live_design! {
             height: Fill,
 
             flow: Down,
-            spacing: 30,
             align: {x: 0.5, y: 0.5},
 
-            <Icon> {
-                draw_icon: {
-                    svg_file: dep("crate://self/resources/icons/chat.svg"),
-                    color: #D0D5DD
+            <View> {
+                width: Fill,
+                height: Fill,
+                flow: Down,
+                spacing: 30,
+                align: {x: 0.5, y: 0.5},
+
+                <Icon> {
+                    draw_icon: {
+                        svg_file: dep("crate://self/resources/icons/chat.svg"),
+                        color: #D0D5DD
+                    }
+                    icon_walk: {width: 128, height: 128}
                 }
-                icon_walk: {width: 128, height: 128}
-            }
-            <Label> {
-                draw_text: {
-                    text_style: <REGULAR_FONT>{font_size: 14},
-                    color: #667085
+
+                <Label> {
+                    draw_text: {
+                        text_style: <REGULAR_FONT>{font_size: 14},
+                        color: #667085
+                    }
+                    text: "Start chatting by choosing a model from above"
                 }
-                text: "Start chatting by choosing a model from above"
             }
+
+            <View> {
+                width: Fill, height: Fit
+                flow: Down,
+                align: {x: 0.5, y: 0.5},
+                filler = <View> { width: Fill, height: Fill }
+                chat_input = <ChatPromptInput> {}
+            }
+
         }
 
         empty_conversation = <View> {

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -722,11 +722,9 @@ impl ChatPanel {
     }
 
     fn unload_model(&mut self, cx: &mut Cx, store: &mut Store) {
-        let mut downloaded_files = store.downloaded_files.clone();
-        downloaded_files.sort_by(|a, b| b.downloaded_at.cmp(&a.downloaded_at));
-
+        let downloaded_model_empty = store.downloaded_files.is_empty();
         self.state = ChatPanelState::Unload {
-            downloaded_model_empty: downloaded_files.is_empty(),
+            downloaded_model_empty,
         };
 
         self.view(id!(main)).set_visible(false);

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -192,6 +192,56 @@ live_design! {
 
         flow: Overlay,
 
+        no_downloaded_model = <View> {
+            width: Fill,
+            height: Fill,
+
+            flow: Down,
+            align: {x: 0.5, y: 0.5},
+
+            <View> {
+                width: Fill,
+                height: Fill,
+                flow: Down,
+                spacing: 30,
+                align: {x: 0.5, y: 0.5},
+
+                <Label> {
+                    draw_text: {
+                        text_style: <REGULAR_FONT>{font_size: 12},
+                        color: #667085
+                    }
+                    text: "You haven’t downloaded any models yet."
+                }
+                go_to_discover_button = <RoundedView> {
+                    width: Fit,
+                    height: Fit,
+                    cursor: Arrow,
+
+                    draw_bg: { color: #fff, border_color: #D0D5DD, border_width: 1}
+
+                    button_label = <Label> {
+                        margin: {top: 14, right: 12, bottom: 14, left: 12}
+                        text: "Go To Discover"
+                        draw_text: {
+                            text_style: <BOLD_FONT>{font_size: 12},
+                            fn get_color(self) -> vec4 {
+                                return #087443;
+                            }
+                        }
+                    }
+                }
+            }
+
+            <View> {
+                width: Fill, height: Fit
+                flow: Down,
+                align: {x: 0.5, y: 0.5},
+                chat_input = <ChatPromptInput> {}
+            }
+
+        }
+
         no_model = <View> {
             width: Fill,
             height: Fill,
@@ -288,15 +338,24 @@ live_design! {
     }
 }
 
-#[derive(Default, PartialEq)]
+#[derive(PartialEq)]
 enum ChatPanelState {
-    #[default]
-    Unload,
+    Unload {
+        downloaded_model_empty: bool,
+    },
     Idle,
     Streaming {
         auto_scroll_pending: bool,
         auto_scroll_cancellable: bool,
     },
+}
+
+impl Default for ChatPanelState {
+    fn default() -> ChatPanelState {
+        ChatPanelState::Unload {
+            downloaded_model_empty: true,
+        }
+    }
 }
 
 #[derive(Live, LiveHook, Widget)]
@@ -342,6 +401,9 @@ impl Widget for ChatPanel {
                     // Redraw because we expect to see new or updated chat entries
                     self.redraw(cx);
                 }
+                ChatPanelState::Unload {
+                    downloaded_model_empty: _,
+                } => self.unload_model(cx, store),
                 _ => {}
             }
         }
@@ -419,6 +481,8 @@ impl Widget for ChatPanel {
 
 impl WidgetMatchEvent for ChatPanel {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        let widget_uid = self.widget_uid();
+
         for action in actions {
             match action.as_widget_action().cast() {
                 ModelSelectorAction::Selected(downloaded_file) => {
@@ -464,7 +528,7 @@ impl WidgetMatchEvent for ChatPanel {
                         .as_ref()
                         .map_or(false, |chat| chat.file_id == file_id)
                     {
-                        self.unload_model(cx);
+                        self.unload_model(cx, store);
                         store.current_chat = None;
                         store.eject_model().expect("Failed to eject model");
                     }
@@ -499,7 +563,16 @@ impl WidgetMatchEvent for ChatPanel {
                     }
                 }
             }
-            ChatPanelState::Unload => {}
+            _ => {}
+        }
+
+        if let Some(fe) = self
+            .view(id!(no_downloaded_model.go_to_discover_button))
+            .finger_up(actions)
+        {
+            if fe.was_tap() {
+                cx.widget_action(widget_uid, &scope.path, ChatPanelAction::NavigateToDiscover);
+            }
         }
     }
 }
@@ -533,7 +606,9 @@ impl ChatPanel {
                 let list = self.portal_list(id!(chat));
                 jump_to_bottom.set_visible(has_messages && list.further_items_bellow_exist());
             }
-            ChatPanelState::Unload => {
+            ChatPanelState::Unload {
+                downloaded_model_empty: _,
+            } => {
                 jump_to_bottom.set_visible(false);
             }
         }
@@ -558,7 +633,9 @@ impl ChatPanel {
                 );
                 self.show_prompt_input_stop_icon(cx);
             }
-            ChatPanelState::Unload => {}
+            ChatPanelState::Unload {
+                downloaded_model_empty: _,
+            } => {}
         }
     }
 
@@ -639,15 +716,38 @@ impl ChatPanel {
         self.view(id!(main)).set_visible(true);
         self.view(id!(empty_conversation)).set_visible(true);
         self.view(id!(no_model)).set_visible(false);
+        self.view(id!(no_downloaded_model)).set_visible(false);
 
         store.load_model(&downloaded_file.file);
     }
 
-    fn unload_model(&mut self, cx: &mut Cx) {
-        self.state = ChatPanelState::Unload;
+    fn unload_model(&mut self, cx: &mut Cx, store: &mut Store) {
+        let mut downloaded_files = store.downloaded_files.clone();
+        downloaded_files.sort_by(|a, b| b.downloaded_at.cmp(&a.downloaded_at));
+
+        self.state = ChatPanelState::Unload {
+            downloaded_model_empty: downloaded_files.is_empty(),
+        };
+
         self.view(id!(main)).set_visible(false);
         self.view(id!(empty_conversation)).set_visible(false);
-        self.view(id!(no_model)).set_visible(true);
+
+        match self.state {
+            ChatPanelState::Unload {
+                downloaded_model_empty: true,
+            } => {
+                self.view(id!(no_downloaded_model)).set_visible(true);
+                self.view(id!(no_model)).set_visible(false);
+            }
+            ChatPanelState::Unload {
+                downloaded_model_empty: false,
+            } => {
+                self.view(id!(no_model)).set_visible(true);
+                self.view(id!(no_downloaded_model)).set_visible(false)
+            }
+            _ => {}
+        }
+
         self.model_selector(id!(model_selector)).deselect(cx);
         self.view.redraw(cx);
     }
@@ -699,5 +799,6 @@ impl ChatPanel {
 #[derive(Clone, DefaultNone, Debug)]
 pub enum ChatPanelAction {
     UnloadIfActive(FileID),
+    NavigateToDiscover,
     None,
 }

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -239,11 +239,29 @@ impl Widget for ModelSelector {
         let mut downloaded_files = store.downloaded_files.clone();
         downloaded_files.sort_by(|a, b| b.downloaded_at.cmp(&a.downloaded_at));
 
+        let choose_label = self.label(id!(choose.label));
         if downloaded_files.is_empty() {
-            self.label(id!(choose.label))
-                .set_text("No Available Models");
+            choose_label.set_text("No Available Models");
+            let color = vec3(0.596, 0.635, 0.702);
+            choose_label.apply_over(
+                cx,
+                live! {
+                    draw_text: {
+                        color: (color)
+                    }
+                },
+            );
         } else {
-            self.label(id!(choose.label)).set_text("Choose a Model");
+            choose_label.set_text("Choose a Model");
+            let color = vec3(0.0, 0.0, 0.0);
+            choose_label.apply_over(
+                cx,
+                live! {
+                    draw_text: {
+                        color: (color)
+                    }
+                },
+            );
         }
 
         self.view.draw_walk(cx, scope, walk)

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -236,11 +236,10 @@ impl Widget for ModelSelector {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let store = scope.data.get::<Store>().unwrap();
 
-        let mut downloaded_files = store.downloaded_files.clone();
-        downloaded_files.sort_by(|a, b| b.downloaded_at.cmp(&a.downloaded_at));
-
+        let downloaded_model_empty = store.downloaded_files.is_empty();
         let choose_label = self.label(id!(choose.label));
-        if downloaded_files.is_empty() {
+
+        if downloaded_model_empty {
             choose_label.set_text("No Available Models");
             let color = vec3(0.596, 0.635, 0.702);
             choose_label.apply_over(

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -173,7 +173,7 @@ live_design! {
 
                 align: {x: 0.5, y: 0.5},
 
-                <Label> {
+                label = <Label> {
                     draw_text:{
                         text_style: <BOLD_FONT>{font_size: 11},
                         color: #000
@@ -234,6 +234,18 @@ impl Widget for ModelSelector {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let store = scope.data.get::<Store>().unwrap();
+
+        let mut downloaded_files = store.downloaded_files.clone();
+        downloaded_files.sort_by(|a, b| b.downloaded_at.cmp(&a.downloaded_at));
+
+        if downloaded_files.is_empty() {
+            self.label(id!(choose.label))
+                .set_text("No Available Models");
+        } else {
+            self.label(id!(choose.label)).set_text("Choose a Model");
+        }
+
         self.view.draw_walk(cx, scope, walk)
     }
 }


### PR DESCRIPTION
update to latest designs.


when there are downloaded models and none of them are selected:
- always show message input

![Screenshot from 2024-05-03 05-48-08](https://github.com/project-robius/moxin/assets/66457708/3a4765c8-12af-4679-95af-aeca97c76c63)


when there are no downloaded models:
- update texts
-  always show message input
- show button "go to discover"
- update text color

![image](https://github.com/project-robius/moxin/assets/66457708/da1a67b0-4d16-47dd-a86e-b8cf0a9d5de8)

