### PR TITLE
Add rotation to downloads collapse icon

### DIFF
--- a/moxin-frontend/src/landing/downloads.rs
+++ b/moxin-frontend/src/landing/downloads.rs
@@ -212,7 +212,7 @@ impl Downloads {
     }
 
     fn set_collapse_button_open(&mut self, cx: &mut Cx, is_open: bool) {
-        let rotation_angle = if is_open { 180.0 } else { 0.0 };
+        let rotation_angle = if is_open { 0.0 } else { 180.0 };
         self.icon(id!(collapse.icon))
         .apply_over(cx, 
             live! {

--- a/moxin-frontend/src/shared/icon.rs
+++ b/moxin-frontend/src/shared/icon.rs
@@ -15,6 +15,39 @@ live_design! {
             height: Fit,
         }
 
+        draw_icon: {
+            uniform rotation_angle: 0.0,
+            fn clip_and_transform_vertex(self, rect_pos: vec2, rect_size: vec2) -> vec4 {
+                let clipped: vec2 = clamp(
+                    self.geom_pos * rect_size + rect_pos,
+                    self.draw_clip.xy,
+                    self.draw_clip.zw
+                )
+                self.pos = (clipped - rect_pos) / rect_size
+
+                // Calculate the texture coordinates based on the rotation angle
+                let angle_rad = self.rotation_angle * 3.14159265359 / 180.0;
+                let cos_angle = cos(angle_rad);
+                let sin_angle = sin(angle_rad);
+                let rot_matrix = mat2(
+                    cos_angle, -sin_angle,
+                    sin_angle, cos_angle
+                );
+                self.tex_coord1 = mix(
+                    self.icon_t1.xy,
+                    self.icon_t2.xy,
+                    (rot_matrix * (self.pos.xy - vec2(0.5))) + vec2(0.5)
+                );
+
+                return self.camera_projection * (self.camera_view * (self.view_transform * vec4(
+                    clipped.x,
+                    clipped.y,
+                    self.draw_depth + self.draw_zbias,
+                    1.
+                )))
+            }
+        }
+
         draw_bg: {
             instance color: #0000,
             fn pixel(self) -> vec4 {


### PR DESCRIPTION
Adds rotation to the download mangers' collapse icon to match the collapsed state.
Also adds a rotation_angle flag to the `Icon` widget.

https://github.com/project-robius/moxin/assets/22042418/207b2ac5-2ef2-4aaa-9f27-4bb11fcea024

