### PR TITLE
Recover search backend errors

### DIFF
--- a/moxin-frontend/src/data/search.rs
+++ b/moxin-frontend/src/data/search.rs
@@ -24,7 +24,6 @@ pub enum SearchState {
     Pending(SearchCommand, Option<SearchCommand>),
     Errored,
 }
-
 pub struct Search {
     pub keyword: Option<String>,
     pub sender: Sender<SearchAction>,
@@ -121,7 +120,7 @@ impl Search {
         });
     }
 
-    pub fn process_results(&mut self, backend: &Backend) -> Result<Vec<Model>> {
+    pub fn process_results(&mut self, backend: &Backend) -> Result<Option<Vec<Model>>> {
         for msg in self.receiver.try_iter() {
             match msg {
                 SearchAction::Results(models) => {
@@ -142,7 +141,7 @@ impl Search {
                             }
                             None => {}
                         }
-                        return Ok(models);
+                        return Ok(Some(models));
                     } else {
                         return Err(anyhow!("Client was not expecting to receive results"));
                     }
@@ -153,7 +152,7 @@ impl Search {
                 }
             }
         }
-        Err(anyhow!("Unkown error fetching models from the server"))
+        return Ok(None)
     }
 
     pub fn is_pending(&self) -> bool {

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -443,11 +443,17 @@ impl Store {
     }
 
     fn update_search_results(&mut self) {
-        if let Ok(models) = self.search.process_results(&self.backend) {
-            self.set_models(models);
-            self.sort_models_by_current_criteria();
-        } else {
-            self.set_models(vec![]);
+        match self.search.process_results(&self.backend) {
+            Ok(Some(models)) => {
+                self.set_models(models);
+                self.sort_models_by_current_criteria();
+            }
+            Ok(None) => {
+                // No results arrived, do nothing
+            }
+            Err(_) => {
+                self.set_models(vec![]);
+            }
         }
     }
 

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -446,6 +446,8 @@ impl Store {
         if let Ok(models) = self.search.process_results(&self.backend) {
             self.set_models(models);
             self.sort_models_by_current_criteria();
+        } else {
+            self.set_models(vec![]);
         }
     }
 
@@ -586,6 +588,10 @@ impl Store {
     }
 
     pub fn search_is_loading(&self) -> bool {
-        self.search.pending
+        self.search.is_pending()
+    }
+
+    pub fn search_is_errored(&self) -> bool {
+        self.search.was_error()
     }
 }

--- a/moxin-frontend/src/landing/landing_screen.rs
+++ b/moxin-frontend/src/landing/landing_screen.rs
@@ -121,7 +121,7 @@ impl Widget for LandingScreen {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let store = scope.data.get::<Store>().unwrap();
-        if store.search_is_loading() {
+        if store.search_is_loading() || store.search_is_errored() {
             self.view(id!(heading_with_filters)).set_visible(false);
             self.view(id!(heading_no_filters)).set_visible(false);
             self.sorting(id!(sorting)).set_visible(cx, false);

--- a/moxin-frontend/src/landing/model_list.rs
+++ b/moxin-frontend/src/landing/model_list.rs
@@ -44,6 +44,21 @@ live_design! {
             }
             search_loading = <SearchLoading> {}
         }
+
+        search_error = <View> {
+            width: Fill,
+            height: Fill,
+            visible: false,
+            align: {x: 0.5, y: 0.5},
+    
+            <Label> {
+                draw_text:{
+                    text_style: <REGULAR_FONT>{font_size: 13},
+                    color: #000
+                }
+                text: "Error fetching models. Please check your internet connection and try again."
+            }
+        }
     }
 }
 
@@ -51,6 +66,9 @@ live_design! {
 pub struct ModelList {
     #[deref]
     view: View,
+
+    #[rust]
+    loading_delay: Timer,
 }
 
 impl Widget for ModelList {
@@ -59,15 +77,11 @@ impl Widget for ModelList {
         self.widget_match_event(cx, event, scope);
 
         if let Event::Signal = event {
-            let store = scope.data.get::<Store>().unwrap();
-            let is_loading = store.search_is_loading();
+            self.loading_delay = cx.start_timeout(0.2);
+        }
 
-            self.view(id!(loading)).set_visible(is_loading);
-            if is_loading {
-                self.search_loading(id!(search_loading)).animate(cx);
-            } else {
-                self.search_loading(id!(search_loading)).stop_animation();
-            }
+        if self.loading_delay.is_event(event).is_some() {
+            self.update_loading_and_error_message(cx, scope);
         }
     }
 
@@ -112,6 +126,7 @@ impl WidgetMatchEvent for ModelList {
         for action in actions.iter() {
             match action.as_widget_action().cast() {
                 StoreAction::Search(_) | StoreAction::ResetSearch => {
+                    self.view(id!(search_error)).set_visible(false);
                     self.view(id!(loading)).set_visible(true);
                     self.search_loading(id!(search_loading)).animate(cx);
                     portal_list.set_first_id_and_scroll(0, 0.0);
@@ -132,5 +147,21 @@ impl WidgetMatchEvent for ModelList {
                 cx.widget_action(widget_uid, &scope.path, ModelListAction::ScrolledNotAtTop);
             }
         }
+    }
+}
+
+impl ModelList {
+    fn update_loading_and_error_message(&mut self, cx: &mut Cx, scope: &mut Scope) {
+        let store = scope.data.get::<Store>().unwrap();
+        let is_loading = store.search_is_loading();
+        self.view(id!(loading)).set_visible(is_loading);
+        if is_loading {
+            self.search_loading(id!(search_loading)).animate(cx);
+        } else {
+            self.search_loading(id!(search_loading)).stop_animation();
+        }
+
+        let is_errored = store.search_is_errored();
+        self.view(id!(search_error)).set_visible(is_errored);
     }
 }


### PR DESCRIPTION
This PR fixes issues with internet disconnection or unavailable server errors, which was breaking the Explore section once it happened.

Now, the user is informed when there is a connectivity issue. Also, the application keeps responsive to try again the search.
