### PR TITLE
Resume and Start chat buttons from landing page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,8 @@ dependencies = [
 [[package]]
 name = "wasmedge-macro"
 version = "0.6.1"
-source = "git+https://github.com/WasmEdge/wasmedge-rust-sdk.git?rev=1ef2434#1ef2434a84f1b78e769421ddf422a593593c6f68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe80d95a88e9ac87b6aaf7bc9acd1fdfcd92045db2bf41a2262f623e2406a92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2359,8 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sdk"
-version = "0.13.2"
-source = "git+https://github.com/WasmEdge/wasmedge-rust-sdk.git?rev=1ef2434#1ef2434a84f1b78e769421ddf422a593593c6f68"
+version = "0.13.5-newapi"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4a1bf8d775c0ff6aa2c15369ebf6c1dafe041be01aef1cc54734b395fceeed"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2374,8 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sys"
-version = "0.17.5"
-source = "git+https://github.com/WasmEdge/wasmedge-rust-sdk.git?rev=1ef2434#1ef2434a84f1b78e769421ddf422a593593c6f68"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1321e59863569b48630846734f3b77759e9f010e291c9ce3336fd77461307ce"
 dependencies = [
  "bindgen",
  "cfg-if",
@@ -2401,8 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-types"
-version = "0.4.4"
-source = "git+https://github.com/WasmEdge/wasmedge-rust-sdk.git?rev=1ef2434#1ef2434a84f1b78e769421ddf422a593593c6f68"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8bfc548253718d2013a8fa9cc9ccc00241e6216f36ee071fa8d7efe2b46c5f"
 dependencies = [
  "thiserror",
  "wat",

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -159,13 +159,7 @@ impl LiveRegister for App {
         makepad_widgets::live_design(cx);
 
         // Shared
-        crate::shared::styles::live_design(cx);
-        crate::shared::resource_imports::live_design(cx);
-        crate::shared::widgets::live_design(cx);
-        crate::shared::icon::live_design(cx);
-        crate::shared::modal::live_design(cx);
-        crate::shared::external_link::live_design(cx);
-        crate::shared::popup::live_design(cx);
+        crate::shared::live_design(cx);
 
         // Landing
         crate::landing::shared::live_design(cx);

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -247,6 +247,10 @@ impl MatchEvent for App {
                     self.store.download_file(file, model);
                     self.ui.redraw(cx);
                 }
+                ModelFileItemAction::Chat => {
+                    let chat_radio_button = self.ui.radio_button(id!(chat_tab));
+                    chat_radio_button.select(cx, &mut Scope::empty());
+                }
                 _ => {}
             }
 

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -158,39 +158,10 @@ impl LiveRegister for App {
     fn live_register(cx: &mut Cx) {
         makepad_widgets::live_design(cx);
 
-        // Shared
         crate::shared::live_design(cx);
-
-        // Landing
-        crate::landing::shared::live_design(cx);
-        crate::landing::model_files_tags::live_design(cx);
-        crate::landing::model_files_item::live_design(cx);
-        crate::landing::model_files_list::live_design(cx);
-        crate::landing::model_files::live_design(cx);
-        crate::landing::model_card::live_design(cx);
-        crate::landing::model_list::live_design(cx);
-        crate::landing::landing_screen::live_design(cx);
-        crate::landing::search_bar::live_design(cx);
-        crate::landing::search_loading::live_design(cx);
-        crate::landing::sorting::live_design(cx);
-        crate::landing::downloads::live_design(cx);
-        crate::landing::download_item::live_design(cx);
-
-        // Chat
-        crate::chat::chat_screen::live_design(cx);
-        crate::chat::chat_panel::live_design(cx);
-        crate::chat::chat_line::live_design(cx);
-        crate::chat::chat_line_loading::live_design(cx);
-        crate::chat::chat_history::live_design(cx);
-        crate::chat::model_info::live_design(cx);
-        crate::chat::model_selector::live_design(cx);
-        crate::chat::model_selector_list::live_design(cx);
-
-        // My Models
-        crate::my_models::my_models_screen::live_design(cx);
-        crate::my_models::downloaded_files_table::live_design(cx);
-        crate::my_models::delete_model_modal::live_design(cx);
-        crate::my_models::model_info_modal::live_design(cx);
+        crate::landing::live_design(cx);
+        crate::chat::live_design(cx);
+        crate::my_models::live_design(cx);
     }
 }
 

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -5,7 +5,7 @@ use crate::landing::model_card::{ModelCardViewAllModalWidgetRefExt, ViewAllModal
 use crate::landing::model_files_item::ModelFileItemAction;
 use crate::my_models::delete_model_modal::{DeleteModelAction, DeleteModelModalWidgetRefExt};
 use crate::my_models::model_info_modal::{ModelInfoAction, ModelInfoModalWidgetRefExt};
-use crate::shared::actions::DownloadedFileAction;
+use crate::shared::actions::ChatAction;
 use crate::shared::modal::ModalWidgetRefExt;
 use crate::shared::popup::{PopupAction, PopupWidgetRefExt};
 use makepad_widgets::*;
@@ -265,7 +265,7 @@ impl MatchEvent for App {
                 self.ui.redraw(cx);
             }
 
-            if let DownloadedFileAction::StartChat(_) = action.as_widget_action().cast() {
+            if let ChatAction::Start(_) = action.as_widget_action().cast() {
                 let chat_radio_button = self.ui.radio_button(id!(chat_tab));
                 chat_radio_button.select(cx, &mut Scope::empty());
             }
@@ -280,7 +280,7 @@ impl MatchEvent for App {
                 discover_radio_button.select(cx, &mut Scope::empty());
             }
 
-            if let DownloadedFileAction::ResumeChat(_) = action.as_widget_action().cast() {
+            if let ChatAction::Resume(_) = action.as_widget_action().cast() {
                 let chat_radio_button = self.ui.radio_button(id!(chat_tab));
                 chat_radio_button.select(cx, &mut Scope::empty());
             }

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -4,8 +4,8 @@ use crate::landing::download_item::DownloadItemAction;
 use crate::landing::model_card::{ModelCardViewAllModalWidgetRefExt, ViewAllModalAction};
 use crate::landing::model_files_item::ModelFileItemAction;
 use crate::my_models::delete_model_modal::{DeleteModelAction, DeleteModelModalWidgetRefExt};
-use crate::my_models::downloaded_files_table::DownloadedFileAction;
 use crate::my_models::model_info_modal::{ModelInfoAction, ModelInfoModalWidgetRefExt};
+use crate::shared::actions::DownloadedFileAction;
 use crate::shared::modal::ModalWidgetRefExt;
 use crate::shared::popup::{PopupAction, PopupWidgetRefExt};
 use makepad_widgets::*;
@@ -246,10 +246,6 @@ impl MatchEvent for App {
                 ModelFileItemAction::Download(file, model) => {
                     self.store.download_file(file, model);
                     self.ui.redraw(cx);
-                }
-                ModelFileItemAction::Chat => {
-                    let chat_radio_button = self.ui.radio_button(id!(chat_tab));
-                    chat_radio_button.select(cx, &mut Scope::empty());
                 }
                 _ => {}
             }

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -512,6 +512,7 @@ impl WidgetMatchEvent for ChatPanel {
 
             match action.as_widget_action().cast() {
                 DownloadedFileAction::StartChat(file_id) => {
+                    println!("Start chat with file_id: {:?}", file_id);
                     let store = scope.data.get_mut::<Store>().unwrap();
                     let downloaded_file = store
                         .downloaded_files

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -1,9 +1,9 @@
 use makepad_widgets::*;
 use moxin_protocol::data::{DownloadedFile, FileID};
 
-use super::{chat_history::ChatHistoryAction, model_selector::ModelSelectorWidgetExt};
 use crate::{
     chat::{
+        chat_history::ChatHistoryAction,
         chat_line::{ChatLineAction, ChatLineWidgetRefExt},
         model_selector::ModelSelectorWidgetExt,
         model_selector_list::ModelSelectorAction,

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -2,12 +2,15 @@ use makepad_widgets::*;
 use moxin_protocol::data::{DownloadedFile, FileID};
 
 use super::{chat_history::ChatHistoryAction, model_selector::ModelSelectorWidgetExt};
-use crate::chat::{
-    chat_line::{ChatLineAction, ChatLineWidgetRefExt},
-    model_selector_list::ModelSelectorAction,
+use crate::{
+    chat::{
+        chat_line::{ChatLineAction, ChatLineWidgetRefExt},
+        model_selector::ModelSelectorWidgetExt,
+        model_selector_list::ModelSelectorAction,
+    },
+    data::store::Store,
+    shared::actions::DownloadedFileAction,
 };
-use crate::data::store::Store;
-use crate::my_models::downloaded_files_table::DownloadedFileAction;
 
 live_design! {
     import makepad_widgets::base::*;

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -512,7 +512,6 @@ impl WidgetMatchEvent for ChatPanel {
 
             match action.as_widget_action().cast() {
                 DownloadedFileAction::StartChat(file_id) => {
-                    println!("Start chat with file_id: {:?}", file_id);
                     let store = scope.data.get_mut::<Store>().unwrap();
                     let downloaded_file = store
                         .downloaded_files

--- a/moxin-frontend/src/chat/chat_panel.rs
+++ b/moxin-frontend/src/chat/chat_panel.rs
@@ -9,7 +9,7 @@ use crate::{
         model_selector_list::ModelSelectorAction,
     },
     data::store::Store,
-    shared::actions::DownloadedFileAction,
+    shared::actions::ChatAction,
 };
 
 live_design! {
@@ -511,7 +511,7 @@ impl WidgetMatchEvent for ChatPanel {
             }
 
             match action.as_widget_action().cast() {
-                DownloadedFileAction::StartChat(file_id) => {
+                ChatAction::Start(file_id) => {
                     let store = scope.data.get_mut::<Store>().unwrap();
                     let downloaded_file = store
                         .downloaded_files

--- a/moxin-frontend/src/chat/mod.rs
+++ b/moxin-frontend/src/chat/mod.rs
@@ -1,8 +1,22 @@
 pub mod chat_history;
-pub mod chat_line;
+pub mod chat_history;
 pub mod chat_line_loading;
+pub mod chat_line;
 pub mod chat_panel;
 pub mod chat_screen;
 pub mod model_info;
-pub mod model_selector;
 pub mod model_selector_list;
+pub mod model_selector;
+
+use makepad_widgets::Cx;
+
+pub fn live_design(cx: &mut Cx) {
+    chat_history::live_design(cx);
+    chat_line_loading::live_design(cx);
+    chat_line::live_design(cx);
+    chat_panel::live_design(cx);
+    chat_screen::live_design(cx);
+    model_info::live_design(cx);
+    model_selector_list::live_design(cx);
+    model_selector::live_design(cx);
+}

--- a/moxin-frontend/src/chat/mod.rs
+++ b/moxin-frontend/src/chat/mod.rs
@@ -1,12 +1,11 @@
 pub mod chat_history;
-pub mod chat_history;
-pub mod chat_line_loading;
 pub mod chat_line;
+pub mod chat_line_loading;
 pub mod chat_panel;
 pub mod chat_screen;
 pub mod model_info;
-pub mod model_selector_list;
 pub mod model_selector;
+pub mod model_selector_list;
 
 use makepad_widgets::Cx;
 

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -1,6 +1,6 @@
 use crate::{
-    data::store::Store, my_models::downloaded_files_table::DownloadedFileAction,
-    shared::utils::format_model_size,
+    data::store::Store,
+    shared::{actions::DownloadedFileAction, utils::format_model_size},
 };
 use makepad_widgets::*;
 use moxin_protocol::data::DownloadedFile;

--- a/moxin-frontend/src/chat/model_selector.rs
+++ b/moxin-frontend/src/chat/model_selector.rs
@@ -1,6 +1,6 @@
 use crate::{
     data::store::Store,
-    shared::{actions::DownloadedFileAction, utils::format_model_size},
+    shared::{actions::ChatAction, utils::format_model_size},
 };
 use makepad_widgets::*;
 use moxin_protocol::data::DownloadedFile;
@@ -234,7 +234,7 @@ impl WidgetMatchEvent for ModelSelector {
             }
 
             match action.as_widget_action().cast() {
-                DownloadedFileAction::StartChat(file_id) => {
+                ChatAction::Start(file_id) => {
                     let downloaded_file = store
                         .downloaded_files
                         .iter()

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -616,9 +616,9 @@ impl Store {
             .files
             .iter()
             .find(|f| {
-                self.current_chat
+                self.get_current_chat()
                     .as_ref()
-                    .map_or(false, |c| c.file_id == f.id)
+                    .map_or(false, |c| c.borrow().file_id == f.id)
             })
             .map(|f| f.id.clone());
 

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -51,6 +51,7 @@ pub struct DownloadInfo {
 pub struct ModelWithPendingDownloads {
     pub model: Model,
     pub pending_downloads: Vec<PendingDownload>,
+    pub current_file_id: Option<FileID>,
 }
 
 #[derive(Default)]
@@ -611,10 +612,20 @@ impl Store {
             .filter(|d| d.model.id == model_id)
             .cloned()
             .collect();
+        let current_file_id = model
+            .files
+            .iter()
+            .find(|f| {
+                self.current_chat
+                    .as_ref()
+                    .map_or(false, |c| c.file_id == f.id)
+            })
+            .map(|f| f.id.clone());
 
         Some(ModelWithPendingDownloads {
             model: model.clone(),
             pending_downloads,
+            current_file_id,
         })
     }
 

--- a/moxin-frontend/src/landing/mod.rs
+++ b/moxin-frontend/src/landing/mod.rs
@@ -11,3 +11,21 @@ pub mod search_bar;
 pub mod search_loading;
 pub mod shared;
 pub mod sorting;
+
+use makepad_widgets::Cx;
+
+pub fn live_design(cx: &mut Cx) {
+    shared::live_design(cx);
+    model_files_tags::live_design(cx);
+    model_files_item::live_design(cx);
+    model_files_list::live_design(cx);
+    model_files::live_design(cx);
+    model_card::live_design(cx);
+    model_list::live_design(cx);
+    landing_screen::live_design(cx);
+    search_bar::live_design(cx);
+    search_loading::live_design(cx);
+    sorting::live_design(cx);
+    downloads::live_design(cx);
+    download_item::live_design(cx);
+}

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -35,12 +35,9 @@ live_design! {
     ModelCardButton = <CButton> {
         width: 140,
         height: 32,
-        align: {x: 0.5, y: 0.5}
         spacing: 6,
 
-        draw_bg: { color: #099250 }
-
-        icon = <Icon> {
+        icon = {
             draw_icon: {
                 fn get_color(self) -> vec4 {
                     return #fff;
@@ -49,7 +46,7 @@ live_design! {
             icon_walk: {width: 14, height: 14}
         }
 
-        label = <Label> {
+        label = {
             draw_text: {
                 text_style: <REGULAR_FONT>{font_size: 9},
                 fn get_color(self) -> vec4 {
@@ -60,7 +57,7 @@ live_design! {
     }
 
     DownloadButton = <ModelCardButton> {
-        cursor: Hand,
+        draw_bg: { color: #099250, border_color: #099250 }
         label = { text: "Download" }
         icon = { draw_icon: {
             svg_file: (ICON_DOWNLOAD),
@@ -68,12 +65,12 @@ live_design! {
     }
 
     StartChatButton = <ModelCardButton> {
-        draw_bg: { color: #fff, border_color: #099250, border_width: 1}
+        draw_bg: { color: #fff, border_color: #d0d5dd }
         label = {
             text: "Chat with Model"
             draw_text: {
                 fn get_color(self) -> vec4 {
-                    return #099250;
+                    return #087443;
                 }
             }
         }
@@ -81,19 +78,19 @@ live_design! {
             draw_icon: {
                 svg_file: (START_CHAT),
                 fn get_color(self) -> vec4 {
-                    return #099250;
+                    return #087443;
                 }
             }
         }
     }
 
     ResumeChatButton = <ModelCardButton> {
-        draw_bg: { color: #fff, border_color: #099250, border_width: 1}
+        draw_bg: { color: #087443, border_color: #087443 }
         label = {
             text: "Resume Chat"
             draw_text: {
                 fn get_color(self) -> vec4 {
-                    return #099250;
+                    return #fff;
                 }
             }
         }
@@ -101,7 +98,7 @@ live_design! {
             draw_icon: {
                 svg_file: (RESUME_CHAT),
                 fn get_color(self) -> vec4 {
-                    return #099250;
+                    return #fff;
                 }
             }
         }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -217,7 +217,7 @@ impl WidgetMatchEvent for ModelFilesItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let widget_uid = self.widget_uid();
 
-        if self.cbutton(id!(download_button)).tapped(&actions) {
+        if self.cbutton(id!(download_button)).clicked(&actions) {
             let Some(model) = &self.model else { return };
             let Some(file) = &self.file else { return };
 
@@ -228,7 +228,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             );
         }
 
-        if self.cbutton(id!(start_chat_button)).tapped(&actions) {
+        if self.cbutton(id!(start_chat_button)).clicked(&actions) {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
@@ -236,7 +236,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             );
         }
 
-        if self.cbutton(id!(resume_chat_button)).tapped(&actions) {
+        if self.cbutton(id!(resume_chat_button)).clicked(&actions) {
             cx.widget_action(
                 widget_uid,
                 &scope.path,

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -85,7 +85,7 @@ live_design! {
     }
 
     ResumeChatButton = <ModelCardButton> {
-        draw_bg: { color: #087443, border_color: #087443 }
+        draw_bg: { color: #099250, border_color: #099250 }
         label = {
             text: "Resume Chat"
             draw_text: {

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -2,13 +2,14 @@ use makepad_widgets::*;
 use moxin_protocol::data::{File, Model};
 
 use super::model_files_tags::ModelFilesTagsWidgetExt;
+use crate::shared::widgets::c_button::{CButtonSetWidgetExt, CButtonWidgetExt};
 
 live_design! {
     import makepad_widgets::base::*;
     import makepad_widgets::theme_desktop_dark::*;
 
     import crate::shared::styles::*;
-
+    import crate::shared::widgets::c_button::*;
     import crate::landing::model_files_tags::ModelFilesTags;
 
     ICON_DOWNLOAD = dep("crate://self/resources/icons/download.svg")
@@ -30,7 +31,7 @@ live_design! {
         cell4 = <View> { width: 250, height: 56, padding: 10, align: {x: 0.0, y: 0.5} }
     }
 
-    ModelCardButton = <RoundedView> {
+    ModelCardButton = <CButton> {
         width: 140,
         height: 32,
         align: {x: 0.5, y: 0.5}
@@ -68,7 +69,7 @@ live_design! {
     DownloadedButton = <ModelCardButton> {
         draw_bg: { color: #fff, border_color: #099250, border_width: 0.5}
         button_label = {
-            text: "Downloaded"
+            text: "Chat with Model"
             draw_text: {
                 fn get_color(self) -> vec4 {
                     return #099250;
@@ -167,6 +168,7 @@ live_design! {
 #[derive(Clone, DefaultNone, Debug)]
 pub enum ModelFileItemAction {
     Download(File, Model),
+    Chat,
     None,
 }
 
@@ -195,18 +197,20 @@ impl Widget for ModelFilesItem {
 
 impl WidgetMatchEvent for ModelFilesItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if let Some(fd) = self.view(id!(download_button)).finger_down(&actions) {
-            if fd.tap_count == 1 {
-                let widget_uid = self.widget_uid();
-                let Some(model) = &self.model else { return };
-                let Some(file) = &self.file else { return };
+        if self.cbutton(id!(download_button)).tapped(&actions) {
+            let widget_uid = self.widget_uid();
+            let Some(model) = &self.model else { return };
+            let Some(file) = &self.file else { return };
 
-                cx.widget_action(
-                    widget_uid,
-                    &scope.path,
-                    ModelFileItemAction::Download(file.clone(), model.clone()),
-                );
-            }
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                ModelFileItemAction::Download(file.clone(), model.clone()),
+            );
+        }
+
+        if self.cbutton(id!(downloaded_button)).tapped(&actions) {
+            cx.widget_action(self.widget_uid(), &scope.path, ModelFileItemAction::Chat);
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -2,7 +2,7 @@ use makepad_widgets::*;
 use moxin_protocol::data::{File, Model};
 
 use super::model_files_tags::ModelFilesTagsWidgetExt;
-use crate::shared::{actions::DownloadedFileAction, widgets::c_button::CButtonWidgetExt};
+use crate::shared::{actions::ChatAction, widgets::c_button::CButtonWidgetExt};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -232,7 +232,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
-                DownloadedFileAction::StartChat(self.file.as_ref().unwrap().id.clone()),
+                ChatAction::Start(self.file.as_ref().unwrap().id.clone()),
             );
         }
 
@@ -240,7 +240,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
-                DownloadedFileAction::ResumeChat(self.file.as_ref().unwrap().id.clone()),
+                ChatAction::Resume(self.file.as_ref().unwrap().id.clone()),
             );
         }
     }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -2,10 +2,7 @@ use makepad_widgets::*;
 use moxin_protocol::data::{File, Model};
 
 use super::model_files_tags::ModelFilesTagsWidgetExt;
-use crate::{
-    data::store::Store,
-    shared::widgets::c_button::{CButtonSetWidgetExt, CButtonWidgetExt},
-};
+use crate::shared::{actions::DownloadedFileAction, widgets::c_button::CButtonWidgetExt};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -193,7 +190,6 @@ live_design! {
 #[derive(Clone, DefaultNone, Debug)]
 pub enum ModelFileItemAction {
     Download(File, Model),
-    Chat,
     None,
 }
 
@@ -216,20 +212,6 @@ impl Widget for ModelFilesItem {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        if let Some(store) = scope.data.get::<Store>() {
-            if let Some(current_chat) = &store.current_chat {
-                if let Some(file) = &self.file {
-                    if current_chat.file_id == file.id {
-                        self.cbutton(id!(start_chat_button)).set_visible(false);
-                        self.cbutton(id!(resume_chat_button)).set_visible(true);
-                    } else {
-                        self.cbutton(id!(start_chat_button)).set_visible(true);
-                        self.cbutton(id!(resume_chat_button)).set_visible(false);
-                    }
-                }
-            }
-        }
-
         self.view.draw_walk(cx, scope, walk)
     }
 }
@@ -250,11 +232,19 @@ impl WidgetMatchEvent for ModelFilesItem {
         }
 
         if self.cbutton(id!(start_chat_button)).tapped(&actions) {
-            cx.widget_action(widget_uid, &scope.path, ModelFileItemAction::Chat);
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadedFileAction::StartChat(self.file.as_ref().unwrap().id.clone()),
+            );
         }
 
         if self.cbutton(id!(resume_chat_button)).tapped(&actions) {
-            cx.widget_action(widget_uid, &scope.path, ModelFileItemAction::Chat);
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadedFileAction::ResumeChat(self.file.as_ref().unwrap().id.clone()),
+            );
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -137,6 +137,7 @@ impl ModelFilesList {
                     live! { cell4 = {
                         download_pending_button = { visible: true }
                         start_chat_button = { visible: false }
+                        resume_chat_button = { visible: false }
                         download_button = { visible: false }
                     }},
                 );
@@ -171,6 +172,7 @@ impl ModelFilesList {
                     live! { cell4 = {
                         download_pending_button = { visible: false }
                         start_chat_button = { visible: false }
+                        resume_chat_button = { visible: false }
                         download_button = { visible: true }
                     }},
                 );

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -3,7 +3,7 @@ use crate::{
     shared::utils::format_model_size,
 };
 use makepad_widgets::*;
-use moxin_protocol::data::{File, Model, PendingDownload};
+use moxin_protocol::data::{File, FileID, Model, PendingDownload};
 
 use super::model_files_item::ModelFilesItemWidgetRefExt;
 
@@ -57,6 +57,7 @@ impl Widget for ModelFilesList {
         let ModelWithPendingDownloads {
             model,
             pending_downloads,
+            current_file_id,
         } = scope.data.get::<ModelWithPendingDownloads>().unwrap();
         let files = if self.show_featured {
             Store::model_featured_files(model)
@@ -65,7 +66,7 @@ impl Widget for ModelFilesList {
         };
         cx.begin_turtle(walk, self.layout);
 
-        self.draw_files(cx, &model, &files, pending_downloads);
+        self.draw_files(cx, &model, &files, pending_downloads, current_file_id);
         cx.end_turtle_with_area(&mut self.area);
 
         DrawStep::done()
@@ -95,6 +96,7 @@ impl ModelFilesList {
         model: &Model,
         files: &Vec<File>,
         pending_downloads: &Vec<PendingDownload>,
+        current_file_id: &Option<FileID>,
     ) {
         for i in 0..files.len() {
             let item_id = LiveId(i as u64).into();
@@ -134,25 +136,41 @@ impl ModelFilesList {
                     cx,
                     live! { cell4 = {
                         download_pending_button = { visible: true }
-                        downloaded_button = { visible: false }
+                        start_chat_button = { visible: false }
                         download_button = { visible: false }
                     }},
                 );
             } else if files[i].downloaded {
-                item_widget.apply_over(
-                    cx,
-                    live! { cell4 = {
-                        download_pending_button = { visible: false }
-                        downloaded_button = { visible: true }
-                        download_button = { visible: false }
-                    }},
-                );
+                if current_file_id
+                    .as_ref()
+                    .map_or(false, |id| *id == files[i].id)
+                {
+                    item_widget.apply_over(
+                        cx,
+                        live! { cell4 = {
+                            download_pending_button = { visible: false }
+                            start_chat_button = { visible: true }
+                            resume_chat_button = { visible: false }
+                            download_button = { visible: false }
+                        }},
+                    );
+                } else {
+                    item_widget.apply_over(
+                        cx,
+                        live! { cell4 = {
+                            download_pending_button = { visible: false }
+                            start_chat_button = { visible: false }
+                            resume_chat_button = { visible: true }
+                            download_button = { visible: false }
+                        }},
+                    );
+                }
             } else {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
                         download_pending_button = { visible: false }
-                        downloaded_button = { visible: false }
+                        start_chat_button = { visible: false }
                         download_button = { visible: true }
                     }},
                 );

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -150,8 +150,8 @@ impl ModelFilesList {
                         cx,
                         live! { cell4 = {
                             download_pending_button = { visible: false }
-                            start_chat_button = { visible: true }
-                            resume_chat_button = { visible: false }
+                            start_chat_button = { visible: false }
+                            resume_chat_button = { visible: true }
                             download_button = { visible: false }
                         }},
                     );
@@ -160,8 +160,8 @@ impl ModelFilesList {
                         cx,
                         live! { cell4 = {
                             download_pending_button = { visible: false }
-                            start_chat_button = { visible: false }
-                            resume_chat_button = { visible: true }
+                            start_chat_button = { visible: true }
+                            resume_chat_button = { visible: false }
                             download_button = { visible: false }
                         }},
                     );

--- a/moxin-frontend/src/landing/model_list.rs
+++ b/moxin-frontend/src/landing/model_list.rs
@@ -50,7 +50,7 @@ live_design! {
             height: Fill,
             visible: false,
             align: {x: 0.5, y: 0.5},
-    
+
             <Label> {
                 draw_text:{
                     text_style: <REGULAR_FONT>{font_size: 13},

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -540,25 +540,25 @@ pub enum ButtonType {
 #[derive(Live, LiveHook, Widget)]
 pub struct ActionButton {
     #[deref]
-    deref: CButton,
+    cbutton: CButton,
     #[live]
     type_: ButtonType,
 }
 
 impl Widget for ActionButton {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.deref.handle_event(cx, event, scope);
+        self.cbutton.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.deref.draw_walk(cx, scope, walk)
+        self.cbutton.draw_walk(cx, scope, walk)
     }
 }
 
 impl WidgetMatchEvent for ActionButton {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.deref.clicked(actions) {
+        if self.cbutton.clicked(actions) {
             let uid = self.widget_uid().clone();
             let action = match self.type_ {
                 ButtonType::Play => RowAction::PlayClicked,
@@ -574,7 +574,7 @@ impl WidgetMatchEvent for ActionButton {
 impl ActionButtonRef {
     pub fn set_visible(&mut self, visible: bool) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.deref.visible = visible;
+            inner.cbutton.visible = visible;
         }
     }
 }

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -6,7 +6,7 @@ use moxin_protocol::data::DownloadedFile;
 use crate::{
     data::store::Store,
     shared::{
-        actions::DownloadedFileAction, modal::ModalAction, utils::format_model_size,
+        actions::ChatAction, modal::ModalAction, utils::format_model_size,
         widgets::c_button::CButton,
     },
 };
@@ -411,7 +411,7 @@ impl WidgetMatchEvent for DownloadedFilesTable {
                                     cx.widget_action(
                                         widget_uid,
                                         &scope.path,
-                                        DownloadedFileAction::StartChat(df.file.id.clone()),
+                                        ChatAction::Start(df.file.id.clone()),
                                     );
                                 } else {
                                     error!("A play action was dispatched for a model that does not longer exist in the local store");
@@ -430,7 +430,7 @@ impl WidgetMatchEvent for DownloadedFilesTable {
                                     cx.widget_action(
                                         widget_uid,
                                         &scope.path,
-                                        DownloadedFileAction::ResumeChat(df.file.id.clone()),
+                                        ChatAction::Resume(df.file.id.clone()),
                                     );
                                 } else {
                                     error!("A play action was dispatched for a model that does not longer exist in the local store");

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -44,7 +44,19 @@ live_design! {
         }
     }
 
-    ActionButton = {{ActionButton}} {}
+    ActionButton = {{ActionButton}} {
+        draw_bg: {
+            border_color: #ccc,
+        }
+
+        icon = {
+            draw_icon: {
+                fn get_color(self) -> vec4 {
+                    return #087443;
+                }
+            }
+        }
+    }
 
     HeaderRow = <View> {
         align: {x: 0.0, y: 0.5}

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -5,7 +5,7 @@ use moxin_protocol::data::{DownloadedFile, FileID};
 
 use crate::{
     data::store::Store,
-    shared::{modal::ModalAction, utils::format_model_size},
+    shared::{modal::ModalAction, utils::format_model_size, widgets::c_button::CButton},
 };
 
 use super::{
@@ -20,6 +20,7 @@ live_design! {
 
     import crate::shared::styles::*;
     import crate::shared::widgets::*;
+    import crate::shared::widgets::c_button::*;
 
     ICON_START_CHAT = dep("crate://self/resources/icons/start_chat.svg")
     ICON_PLAY = dep("crate://self/resources/icons/play_arrow.svg")
@@ -40,28 +41,7 @@ live_design! {
         }
     }
 
-    ActionButton = {{ActionButton}}<RoundedView> {
-        align: {x: 0.5, y: 0.5}
-        flow: Right
-        width: Fit, height: Fit
-        padding: { top: 15, bottom: 15, left: 8, right: 13}
-        spacing: 10
-        draw_bg: {
-            radius: 2.0,
-            color: #fff,
-            border_width: 1.0,
-            border_color: #ccc,
-        }
-
-        icon = <Icon> {
-            draw_icon: {
-                fn get_color(self) -> vec4 {
-                    return #087443;
-                }
-            }
-            icon_walk: {width: 12, height: 12}
-        }
-    }
+    ActionButton = {{ActionButton}} {}
 
     HeaderRow = <View> {
         align: {x: 0.0, y: 0.5}
@@ -544,48 +524,41 @@ pub enum ButtonType {
 #[derive(Live, LiveHook, Widget)]
 pub struct ActionButton {
     #[deref]
-    view: View,
+    deref: CButton,
     #[live]
     type_: ButtonType,
 }
 
 impl Widget for ActionButton {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        let uid = self.widget_uid().clone();
-        match event.hits(cx, self.view.area()) {
-            Hit::FingerDown(_) => {
-                cx.set_key_focus(self.view.area());
-            }
-            Hit::FingerUp(fe) => {
-                if fe.was_tap() {
-                    let action = match self.type_ {
-                        ButtonType::Play => RowAction::PlayClicked,
-                        ButtonType::Resume => RowAction::ResumeClicked,
-                        ButtonType::Info => RowAction::InfoClicked,
-                        ButtonType::Delete => RowAction::DeleteClicked,
-                    };
-                    cx.widget_action(uid, &scope.path, action);
-                }
-            }
-            Hit::FingerHoverIn(_) => {
-                cx.set_cursor(MouseCursor::Hand);
-            }
-            Hit::FingerHoverOut(_) => {
-                cx.set_cursor(MouseCursor::Arrow);
-            }
-            _ => (),
-        }
+        self.deref.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.view.draw_walk(cx, scope, walk)
+        self.deref.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for ActionButton {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        if self.deref.tapped(actions) {
+            let uid = self.widget_uid().clone();
+            let action = match self.type_ {
+                ButtonType::Play => RowAction::PlayClicked,
+                ButtonType::Resume => RowAction::ResumeClicked,
+                ButtonType::Info => RowAction::InfoClicked,
+                ButtonType::Delete => RowAction::DeleteClicked,
+            };
+            cx.widget_action(uid, &scope.path, action);
+        }
     }
 }
 
 impl ActionButtonRef {
     pub fn set_visible(&mut self, visible: bool) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.view.visible = visible;
+            inner.deref.visible = visible;
         }
     }
 }

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
 
 use makepad_widgets::*;
-use moxin_protocol::data::{DownloadedFile, FileID};
+use moxin_protocol::data::DownloadedFile;
 
 use crate::{
     data::store::Store,
-    shared::{modal::ModalAction, utils::format_model_size, widgets::c_button::CButton},
+    shared::{
+        actions::DownloadedFileAction, modal::ModalAction, utils::format_model_size,
+        widgets::c_button::CButton,
+    },
 };
 
 use super::{
@@ -561,13 +564,6 @@ impl ActionButtonRef {
             inner.deref.visible = visible;
         }
     }
-}
-
-#[derive(Clone, DefaultNone, Debug)]
-pub enum DownloadedFileAction {
-    StartChat(FileID),
-    ResumeChat(FileID),
-    None,
 }
 
 /// Removes dashes, file extension, and capitalizes the first letter of each word.

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -558,7 +558,7 @@ impl Widget for ActionButton {
 
 impl WidgetMatchEvent for ActionButton {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.deref.tapped(actions) {
+        if self.deref.clicked(actions) {
             let uid = self.widget_uid().clone();
             let action = match self.type_ {
                 ButtonType::Play => RowAction::PlayClicked,

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -266,6 +266,7 @@ impl Widget for DownloadedFilesTable {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.file_item_map.clear();
         let filter = match &self.search_status {
             SearchStatus::Filtered(keywords) => Some(keywords.clone()),
             _ => None,

--- a/moxin-frontend/src/my_models/mod.rs
+++ b/moxin-frontend/src/my_models/mod.rs
@@ -2,3 +2,12 @@ pub mod delete_model_modal;
 pub mod downloaded_files_table;
 pub mod model_info_modal;
 pub mod my_models_screen;
+
+use makepad_widgets::Cx;
+
+pub fn live_design(cx: &mut Cx) {
+    my_models_screen::live_design(cx);
+    downloaded_files_table::live_design(cx);
+    delete_model_modal::live_design(cx);
+    model_info_modal::live_design(cx);
+}

--- a/moxin-frontend/src/shared/actions.rs
+++ b/moxin-frontend/src/shared/actions.rs
@@ -1,0 +1,9 @@
+use makepad_widgets::DefaultNone;
+use moxin_protocol::data::FileID;
+
+#[derive(Clone, DefaultNone, Debug)]
+pub enum DownloadedFileAction {
+    StartChat(FileID),
+    ResumeChat(FileID),
+    None,
+}

--- a/moxin-frontend/src/shared/actions.rs
+++ b/moxin-frontend/src/shared/actions.rs
@@ -2,8 +2,8 @@ use makepad_widgets::DefaultNone;
 use moxin_protocol::data::FileID;
 
 #[derive(Clone, DefaultNone, Debug)]
-pub enum DownloadedFileAction {
-    StartChat(FileID),
-    ResumeChat(FileID),
+pub enum ChatAction {
+    Start(FileID),
+    Resume(FileID),
     None,
 }

--- a/moxin-frontend/src/shared/mod.rs
+++ b/moxin-frontend/src/shared/mod.rs
@@ -1,5 +1,6 @@
 use makepad_widgets::Cx;
 
+pub mod actions;
 pub mod external_link;
 pub mod icon;
 pub mod modal;

--- a/moxin-frontend/src/shared/mod.rs
+++ b/moxin-frontend/src/shared/mod.rs
@@ -13,6 +13,7 @@ pub fn live_design(cx: &mut Cx) {
     styles::live_design(cx);
     resource_imports::live_design(cx);
     widgets::live_design(cx);
+    widgets::c_button::live_design(cx);
     icon::live_design(cx);
     modal::live_design(cx);
     external_link::live_design(cx);

--- a/moxin-frontend/src/shared/mod.rs
+++ b/moxin-frontend/src/shared/mod.rs
@@ -1,3 +1,5 @@
+use makepad_widgets::Cx;
+
 pub mod external_link;
 pub mod icon;
 pub mod modal;
@@ -6,3 +8,13 @@ pub mod resource_imports;
 pub mod styles;
 pub mod utils;
 pub mod widgets;
+
+pub fn live_design(cx: &mut Cx) {
+    styles::live_design(cx);
+    resource_imports::live_design(cx);
+    widgets::live_design(cx);
+    icon::live_design(cx);
+    modal::live_design(cx);
+    external_link::live_design(cx);
+    popup::live_design(cx);
+}

--- a/moxin-frontend/src/shared/widgets.rs
+++ b/moxin-frontend/src/shared/widgets.rs
@@ -1,3 +1,5 @@
+pub mod c_button;
+
 use makepad_widgets::*;
 
 live_design! {

--- a/moxin-frontend/src/shared/widgets/c_button.rs
+++ b/moxin-frontend/src/shared/widgets/c_button.rs
@@ -16,13 +16,13 @@ live_design!(
             radius: 2.0,
             color: #fff,
             border_width: 1.0,
-            border_color: #ccc,
+            border_color: #000,
         }
 
         icon = <Icon> {
             draw_icon: {
                 fn get_color(self) -> vec4 {
-                    return #087443;
+                    return #000;
                 }
             }
             icon_walk: {width: 12, height: 12}
@@ -79,10 +79,6 @@ impl CButton {
             CButtonAction::Tapped
         )
     }
-
-    pub fn set_visible(&mut self, visible: bool) {
-        self.deref.visible = visible;
-    }
 }
 
 impl CButtonRef {
@@ -91,12 +87,6 @@ impl CButtonRef {
             widget.tapped(actions)
         } else {
             false
-        }
-    }
-
-    pub fn set_visible(&mut self, visible: bool) {
-        if let Some(mut widget) = self.borrow_mut() {
-            widget.set_visible(visible);
         }
     }
 }

--- a/moxin-frontend/src/shared/widgets/c_button.rs
+++ b/moxin-frontend/src/shared/widgets/c_button.rs
@@ -36,18 +36,18 @@ live_design!(
 #[derive(Widget, Live, LiveHook)]
 pub struct CButton {
     #[deref]
-    deref: View,
+    view: View,
 }
 
 impl Widget for CButton {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.deref.draw_walk(cx, scope, walk)
+        self.view.draw_walk(cx, scope, walk)
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         match event.hits(cx, self.area()) {
             Hit::FingerDown(_) => {
-                cx.set_key_focus(self.deref.area());
+                cx.set_key_focus(self.view.area());
             }
             Hit::FingerUp(up) => {
                 if up.was_tap() {

--- a/moxin-frontend/src/shared/widgets/c_button.rs
+++ b/moxin-frontend/src/shared/widgets/c_button.rs
@@ -1,0 +1,102 @@
+use makepad_widgets::*;
+
+live_design!(
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+    import crate::shared::styles::*;
+    import crate::shared::widgets::*;
+
+    CButton = {{CButton}} <RoundedView> {
+        align: {x: 0.5, y: 0.5}
+        flow: Right
+        width: Fit, height: Fit
+        padding: { top: 15, bottom: 15, left: 8, right: 13}
+        spacing: 10
+        draw_bg: {
+            radius: 2.0,
+            color: #fff,
+            border_width: 1.0,
+            border_color: #ccc,
+        }
+
+        icon = <Icon> {
+            draw_icon: {
+                fn get_color(self) -> vec4 {
+                    return #087443;
+                }
+            }
+            icon_walk: {width: 12, height: 12}
+        }
+
+        label = <Label> {}
+    }
+);
+
+/// An attempt of a custom button, sharable with the rest of the app.
+#[derive(Widget, Live, LiveHook)]
+pub struct CButton {
+    #[deref]
+    deref: View,
+}
+
+impl Widget for CButton {
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.deref.draw_walk(cx, scope, walk)
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        match event.hits(cx, self.area()) {
+            Hit::FingerDown(_) => {
+                cx.set_key_focus(self.deref.area());
+            }
+            Hit::FingerUp(up) => {
+                if up.was_tap() {
+                    cx.widget_action(self.widget_uid(), &scope.path, CButtonAction::Tapped);
+                }
+            }
+            Hit::FingerHoverIn(_) => {
+                cx.set_cursor(MouseCursor::Hand);
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.set_cursor(MouseCursor::Arrow);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone, Debug, DefaultNone)]
+pub enum CButtonAction {
+    Tapped,
+    /// Needed to support `.cast()`.
+    None,
+}
+
+impl CButton {
+    pub fn tapped(&self, actions: &Actions) -> bool {
+        matches!(
+            actions.find_widget_action(self.widget_uid()).cast(),
+            CButtonAction::Tapped
+        )
+    }
+
+    pub fn set_visible(&mut self, visible: bool) {
+        self.deref.visible = visible;
+    }
+}
+
+impl CButtonRef {
+    pub fn tapped(&self, actions: &Actions) -> bool {
+        if let Some(widget) = self.borrow() {
+            widget.tapped(actions)
+        } else {
+            false
+        }
+    }
+
+    pub fn set_visible(&mut self, visible: bool) {
+        if let Some(mut widget) = self.borrow_mut() {
+            widget.set_visible(visible);
+        }
+    }
+}

--- a/moxin-frontend/src/shared/widgets/c_button.rs
+++ b/moxin-frontend/src/shared/widgets/c_button.rs
@@ -51,7 +51,7 @@ impl Widget for CButton {
             }
             Hit::FingerUp(up) => {
                 if up.was_tap() {
-                    cx.widget_action(self.widget_uid(), &scope.path, CButtonAction::Tapped);
+                    cx.widget_action(self.widget_uid(), &scope.path, CButtonAction::Clicked);
                 }
             }
             Hit::FingerHoverIn(_) => {
@@ -67,24 +67,24 @@ impl Widget for CButton {
 
 #[derive(Clone, Debug, DefaultNone)]
 pub enum CButtonAction {
-    Tapped,
+    Clicked,
     /// Needed to support `.cast()`.
     None,
 }
 
 impl CButton {
-    pub fn tapped(&self, actions: &Actions) -> bool {
+    pub fn clicked(&self, actions: &Actions) -> bool {
         matches!(
             actions.find_widget_action(self.widget_uid()).cast(),
-            CButtonAction::Tapped
+            CButtonAction::Clicked
         )
     }
 }
 
 impl CButtonRef {
-    pub fn tapped(&self, actions: &Actions) -> bool {
+    pub fn clicked(&self, actions: &Actions) -> bool {
         if let Some(widget) = self.borrow() {
-            widget.tapped(actions)
+            widget.clicked(actions)
         } else {
             false
         }


### PR DESCRIPTION
# Changes
- Replaces the "Downloaded..." button in the landing page with "Chat with Model" and "Resume".
  - These work the same as in the "My Models" screen.
- Tried to extract a common reusable button called `CButton` (to avoid name conflicts).
- Seems like a small issue with the cursor got fixed in the landing screen by using that button.

# Before
https://github.com/project-robius/moxin/assets/7684329/af64ed9d-1f7e-4e41-9c3b-1732e036581e

# After

https://github.com/project-robius/moxin/assets/7684329/fe195bac-465a-4275-96ab-145cf2b0ae63

https://github.com/project-robius/moxin/assets/7684329/ae417abe-3f57-406a-9f0c-eb0a1bc80b56

