### PR TITLE
Refactor to make use of the original Makepad Button widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.0",
+ "jni-sys",
  "log",
  "thiserror",
  "walkdir",
@@ -794,11 +794,6 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jni-sys"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
 
 [[package]]
 name = "js-sys"
@@ -887,9 +882,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "makepad-android-state"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd004cda8be459fd76954218b76a1249a079fb9360bbca4e724cb7ddb2962857"
+dependencies = [
+ "makepad-jni-sys",
+]
+
+[[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -898,7 +902,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -906,7 +910,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -915,13 +919,13 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "ab_glyph_rasterizer",
  "makepad-html",
  "makepad-platform",
+ "makepad-rustybuzz",
  "makepad-vector",
- "rustybuzz",
  "sdfer",
  "unicode-bidi",
 ]
@@ -929,17 +933,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-id",
 ]
@@ -947,12 +951,18 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
+
+[[package]]
+name = "makepad-jni-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -962,7 +972,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -970,7 +980,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -978,7 +988,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -988,7 +998,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-id",
 ]
@@ -996,17 +1006,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-micro-serde-derive",
 ]
@@ -1014,7 +1024,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1022,17 +1032,18 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
- "jni-sys 0.4.0",
+ "makepad-android-state",
  "makepad-futures",
  "makepad-futures-legacy",
  "makepad-http",
+ "makepad-jni-sys",
  "makepad-objc-sys",
  "makepad-shader-compiler",
  "makepad-wasm-bridge",
@@ -1042,9 +1053,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-rustybuzz"
+version = "0.8.0"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1052,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "ttf-parser",
 ]
@@ -1060,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1069,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1082,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "windows-core 0.51.1",
  "windows-targets 0.48.5",
@@ -1091,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -1099,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "simd-adler32",
 ]
@@ -1107,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -1115,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -1698,21 +1724,6 @@ checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "rustybuzz"
-version = "0.8.0"
-source = "git+https://github.com/RazrFalcon/rustybuzz?rev=a0b8aa3#a0b8aa3ed002550cfea1137655d9ab7569964ae5"
-dependencies = [
- "bitflags 1.3.2",
- "bytemuck",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
 ]
 
 [[package]]
@@ -2462,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#cae2042c711195727b9c147ff5372ef8ba5deead"
+source = "git+https://github.com/makepad/makepad?branch=rik#bd972c6d386e839b3cf885f36099583420cbec01"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -64,21 +64,21 @@ live_design! {
 
                         discover_tab = <SidebarMenuButton> {
                             animator: {selected = {default: on}}
-                            label: "Discover",
+                            text: "Discover",
                             draw_icon: {
-                            svg_file: (ICON_DISCOVER),
+                                svg_file: (ICON_DISCOVER),
                             }
                         }
                         chat_tab = <SidebarMenuButton> {
-                            label: "Chat",
+                            text: "Chat",
                             draw_icon: {
-                            svg_file: (ICON_CHAT),
+                                svg_file: (ICON_CHAT),
                             }
                         }
                         my_models_tab = <SidebarMenuButton> {
-                            label: "My Models",
+                            text: "My Models",
                             draw_icon: {
-                            svg_file: (ICON_MY_MODELS),
+                                svg_file: (ICON_MY_MODELS),
                             }
                         }
                     }

--- a/moxin-frontend/src/landing/download_item.rs
+++ b/moxin-frontend/src/landing/download_item.rs
@@ -10,6 +10,7 @@ live_design! {
     import makepad_widgets::theme_desktop_dark::*;
 
     import crate::shared::styles::*;
+    import crate::shared::widgets::MoxinButton;
 
     ICON_PAUSE = dep("crate://self/resources/icons/pause_download.svg")
     ICON_CANCEL = dep("crate://self/resources/icons/cancel_download.svg")
@@ -126,29 +127,23 @@ live_design! {
         }
     }
 
-    ActionButton = <RoundedView> {
+    ActionButton = <MoxinButton> {
         width: 40,
         height: 40,
-
-        cursor: Hand,
-
-        align: {x: 0.5, y: 0.5}
 
         draw_bg: {
             border_color: #EAECF0,
             border_width: 1.0,
             color: #fff,
+            color_hover: #E2F1F199,
             radius: 2.0,
         }
 
-        icon = <Icon> {
-            draw_icon: {
-                fn get_color(self) -> vec4 {
-                    return #667085;
-                }
-            }
-            icon_walk: {height: 12, margin: {top: 2, right: 4}}
+        draw_icon: {
+            color: #667085;
         }
+
+        icon_walk: { margin: { left: 6 } }
     }
 
     Actions = <View> {
@@ -160,36 +155,26 @@ live_design! {
         align: {x: 0.5, y: 0.5},
 
         pause_button = <ActionButton> {
-            icon = {
-                draw_icon: {
-                    svg_file: (ICON_PAUSE),
-                }
+            draw_icon: {
+                svg_file: (ICON_PAUSE),
             }
-
         }
 
         play_button = <ActionButton> {
-            icon = {
-                draw_icon: {
-                    svg_file: (ICON_PLAY),
-                }
+            draw_icon: {
+                svg_file: (ICON_PLAY),
             }
-
         }
 
         retry_button = <ActionButton> {
-            icon = {
-                draw_icon: {
-                    svg_file: (ICON_RETRY),
-                }
+            draw_icon: {
+                svg_file: (ICON_RETRY),
             }
         }
 
         cancel_button = <ActionButton> {
-            icon = {
-                draw_icon: {
-                    svg_file: (ICON_CANCEL),
-                }
+            draw_icon: {
+                svg_file: (ICON_CANCEL),
             }
         }
     }

--- a/moxin-frontend/src/landing/download_item.rs
+++ b/moxin-frontend/src/landing/download_item.rs
@@ -135,15 +135,13 @@ live_design! {
             border_color: #EAECF0,
             border_width: 1.0,
             color: #fff,
-            color_hover: #E2F1F199,
+            color_hover: #E2F1F1,
             radius: 2.0,
         }
 
         draw_icon: {
             color: #667085;
         }
-
-        icon_walk: { margin: { left: 6 } }
     }
 
     Actions = <View> {
@@ -158,12 +156,14 @@ live_design! {
             draw_icon: {
                 svg_file: (ICON_PAUSE),
             }
+            icon_walk: { margin: { left: 6 } }
         }
 
         play_button = <ActionButton> {
             draw_icon: {
                 svg_file: (ICON_PLAY),
             }
+            icon_walk: { margin: { left: 6 } }
         }
 
         retry_button = <ActionButton> {
@@ -176,6 +176,7 @@ live_design! {
             draw_icon: {
                 svg_file: (ICON_CANCEL),
             }
+            icon_walk: { margin: 0 }
         }
     }
 
@@ -257,9 +258,9 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(pause_button)).set_visible(true);
-                self.view(id!(play_button)).set_visible(false);
-                self.view(id!(retry_button)).set_visible(false);
+                self.button(id!(pause_button)).set_visible(true);
+                self.button(id!(play_button)).set_visible(false);
+                self.button(id!(retry_button)).set_visible(false);
             }
             DownloadState::Paused(progress) => {
                 let paused_color = vec3(0.4, 0.44, 0.52); //#667085
@@ -279,9 +280,9 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(pause_button)).set_visible(false);
-                self.view(id!(play_button)).set_visible(true);
-                self.view(id!(retry_button)).set_visible(false);
+                self.button(id!(pause_button)).set_visible(false);
+                self.button(id!(play_button)).set_visible(true);
+                self.button(id!(retry_button)).set_visible(false);
             }
             DownloadState::Errored(progress) => {
                 let failed_color = vec3(0.7, 0.11, 0.09); // #B42318
@@ -301,9 +302,9 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(pause_button)).set_visible(false);
-                self.view(id!(play_button)).set_visible(false);
-                self.view(id!(retry_button)).set_visible(true);
+                self.button(id!(pause_button)).set_visible(false);
+                self.button(id!(play_button)).set_visible(false);
+                self.button(id!(retry_button)).set_visible(true);
             }
             DownloadState::Completed => ()
         }
@@ -322,41 +323,35 @@ impl Widget for DownloadItem {
 impl WidgetMatchEvent for DownloadItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         for button_id in [id!(play_button), id!(retry_button)] {
-            if let Some(fd) = self.view(button_id).finger_down(&actions) {
+            if self.button(button_id).clicked(&actions) {
                 let Some(file_id) = &self.file_id else { return };
-                if fd.tap_count == 1 {
-                    let widget_uid = self.widget_uid();
-                    cx.widget_action(
-                        widget_uid,
-                        &scope.path,
-                        DownloadItemAction::Play(file_id.clone()),
-                    );
-                }
-            }
-        }
-
-        if let Some(fd) = self.view(id!(pause_button)).finger_down(&actions) {
-            let Some(file_id) = &self.file_id else { return };
-            if fd.tap_count == 1 {
                 let widget_uid = self.widget_uid();
                 cx.widget_action(
                     widget_uid,
                     &scope.path,
-                    DownloadItemAction::Pause(file_id.clone()),
-                );
+                    DownloadItemAction::Play(file_id.clone()),
+                )
             }
         }
 
-        if let Some(fd) = self.view(id!(cancel_button)).finger_down(&actions) {
+        if self.button(id!(pause_button)).clicked(&actions) {
             let Some(file_id) = &self.file_id else { return };
-            if fd.tap_count == 1 {
-                let widget_uid = self.widget_uid();
-                cx.widget_action(
-                    widget_uid,
-                    &scope.path,
-                    DownloadItemAction::Cancel(file_id.clone()),
-                );
-            }
+            let widget_uid = self.widget_uid();
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadItemAction::Pause(file_id.clone()),
+            )
+        }
+
+        if self.button(id!(cancel_button)).clicked(&actions) {
+            let Some(file_id) = &self.file_id else { return };
+            let widget_uid = self.widget_uid();
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadItemAction::Cancel(file_id.clone()),
+            )
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -33,63 +33,9 @@ live_design! {
         cell4 = <View> { width: 250, height: 56, padding: 10, align: {x: 0.0, y: 0.5} }
     }
 
-    ModelCardButton = <Button> {
+    ModelCardButton = <MoxinButton> {
         width: 140,
         height: 32,
-
-        // This shader is based more in the RoundedView shader than the Button shader
-        // It fits better this application UI design
-        draw_bg: {
-            instance color: #0000
-            instance color_hover: #fff
-            instance border_width: 1.0
-            instance border_color: #0000
-            instance border_color_hover: #fff
-            instance radius: 2.5
-            
-            fn get_color(self) -> vec4 {
-                return mix(self.color, mix(self.color, self.color_hover, 0.2), self.hover)
-            }
-            
-            fn get_border_color(self) -> vec4 {
-                return mix(self.border_color, mix(self.border_color, self.border_color_hover, 0.2), self.hover)
-            }
-            
-            fn pixel(self) -> vec4 {
-                let sdf = Sdf2d::viewport(self.pos * self.rect_size)
-                sdf.box(
-                    self.border_width,
-                    self.border_width,
-                    self.rect_size.x - (self.border_width * 2.0),
-                    self.rect_size.y - (self.border_width * 2.0),
-                    max(1.0, self.radius)
-                )
-                sdf.fill_keep(self.get_color())
-                if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
-                }
-                return sdf.result;
-            }
-        }
-
-        draw_icon: {
-            instance color: #fff
-            fn get_color(self) -> vec4 {
-                return mix(
-                    self.color,
-                    mix(self.color, #f, 0.2),
-                    self.hover
-                )
-            }
-        }
-        icon_walk: {width: 14, height: 14}
-
-        draw_text: {
-            text_style: <REGULAR_FONT>{font_size: 9},
-            fn get_color(self) -> vec4 {
-                return #fff;
-            }
-        }
     }
 
     DownloadButton = <ModelCardButton> {

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -69,21 +69,14 @@ live_design! {
         }
     }
 
-    // TODO This is a very temporary solution, we will have a better way to handle this.
     DownloadPendingButton = <ModelCardButton> {
         draw_bg: { color: #fff, border_color: #x155EEF, border_width: 0.5}
         text: "Downloading..."
-
-        // Button disabled
-        grab_key_focus: false
+        enabled: false
 
         draw_text: {
             color: #x155EEF;
         }
-        // draw_icon: {
-        //     // invisible for now
-        //     color: #0000
-        // }
     }
 
     ModelFilesItem = {{ModelFilesItem}}<ModelFilesRow> {
@@ -137,30 +130,10 @@ live_design! {
 
         cell4 = {
             align: {x: 0.5, y: 0.5},
-            download_button_container = <View> {
-                width: Fit,
-                height: Fit,
-                visible: false
-                download_button = <DownloadButton> { }
-            }
-            start_chat_button_container = <View> {
-                width: Fit,
-                height: Fit,
-                visible: false
-                start_chat_button = <StartChatButton> { }
-            }
-            resume_chat_button_container = <View> {
-                width: Fit,
-                height: Fit,
-                visible: false
-                resume_chat_button = <ResumeChatButton> { }
-            }
-            download_pending_button_container = <View> {
-                width: Fit,
-                height: Fit,
-                visible: false
-                download_pending_button = <DownloadPendingButton> { }
-            }
+            download_button = <DownloadButton> { visible: false }
+            start_chat_button = <StartChatButton> { visible: false }
+            resume_chat_button = <ResumeChatButton> { visible: false }
+            download_pending_button = <DownloadPendingButton> { visible: false }
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -10,7 +10,7 @@ live_design! {
     import makepad_draw::shader::std::*;
 
     import crate::shared::styles::*;
-    import crate::shared::widgets::c_button::*;
+    import crate::shared::widgets::MoxinButton;
     import crate::landing::model_files_tags::ModelFilesTags;
 
     ICON_DOWNLOAD = dep("crate://self/resources/icons/download.svg")
@@ -50,9 +50,7 @@ live_design! {
         draw_bg: { color: #fff, color_hover: #09925033, border_color: #d0d5dd }
         text: "Chat with Model"
         draw_text: {
-            fn get_color(self) -> vec4 {
-                return #087443;
-            }
+            color: #087443;
         }
         draw_icon: {
             svg_file: (START_CHAT),
@@ -64,9 +62,7 @@ live_design! {
         draw_bg: { color: #099250, border_color: #09925033 }
         text: "Resume Chat"
         draw_text: {
-            fn get_color(self) -> vec4 {
-                return #fff;
-            }
+            color: #fff;
         }
         draw_icon: {
             svg_file: (RESUME_CHAT),
@@ -82,14 +78,12 @@ live_design! {
         grab_key_focus: false
 
         draw_text: {
-            fn get_color(self) -> vec4 {
-                return #x155EEF;
-            }
+            color: #x155EEF;
         }
-        draw_icon: {
-            // invisible for now
-            color: #0000
-        }
+        // draw_icon: {
+        //     // invisible for now
+        //     color: #0000
+        // }
     }
 
     ModelFilesItem = {{ModelFilesItem}}<ModelFilesRow> {

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -130,10 +130,10 @@ impl ModelFilesList {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button = { visible: true }
-                        start_chat_button = { visible: false }
-                        resume_chat_button = { visible: false }
-                        download_button = { visible: false }
+                        download_pending_button_container = { visible: true }
+                        start_chat_button_container = { visible: false }
+                        resume_chat_button_container = { visible: false }
+                        download_button_container = { visible: false }
                     }},
                 );
             } else if files[i].downloaded {
@@ -144,20 +144,20 @@ impl ModelFilesList {
                     item_widget.apply_over(
                         cx,
                         live! { cell4 = {
-                            download_pending_button = { visible: false }
-                            start_chat_button = { visible: false }
-                            resume_chat_button = { visible: true }
-                            download_button = { visible: false }
+                            download_pending_button_container = { visible: false }
+                            start_chat_button_container = { visible: false }
+                            resume_chat_button_container = { visible: true }
+                            download_button_container = { visible: false }
                         }},
                     );
                 } else {
                     item_widget.apply_over(
                         cx,
                         live! { cell4 = {
-                            download_pending_button = { visible: false }
-                            start_chat_button = { visible: true }
-                            resume_chat_button = { visible: false }
-                            download_button = { visible: false }
+                            download_pending_button_container = { visible: false }
+                            start_chat_button_container = { visible: true }
+                            resume_chat_button_container = { visible: false }
+                            download_button_container = { visible: false }
                         }},
                     );
                 }
@@ -165,10 +165,10 @@ impl ModelFilesList {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button = { visible: false }
-                        start_chat_button = { visible: false }
-                        resume_chat_button = { visible: false }
-                        download_button = { visible: true }
+                        download_pending_button_container = { visible: false }
+                        start_chat_button_container = { visible: false }
+                        resume_chat_button_container = { visible: false }
+                        download_button_container = { visible: true }
                     }},
                 );
             };

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -130,10 +130,10 @@ impl ModelFilesList {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button_container = { visible: true }
-                        start_chat_button_container = { visible: false }
-                        resume_chat_button_container = { visible: false }
-                        download_button_container = { visible: false }
+                        download_pending_button = { visible: true }
+                        start_chat_button = { visible: false }
+                        resume_chat_button = { visible: false }
+                        download_button = { visible: false }
                     }},
                 );
             } else if files[i].downloaded {
@@ -144,20 +144,20 @@ impl ModelFilesList {
                     item_widget.apply_over(
                         cx,
                         live! { cell4 = {
-                            download_pending_button_container = { visible: false }
-                            start_chat_button_container = { visible: false }
-                            resume_chat_button_container = { visible: true }
-                            download_button_container = { visible: false }
+                            download_pending_button = { visible: false }
+                            start_chat_button = { visible: false }
+                            resume_chat_button = { visible: true }
+                            download_button = { visible: false }
                         }},
                     );
                 } else {
                     item_widget.apply_over(
                         cx,
                         live! { cell4 = {
-                            download_pending_button_container = { visible: false }
-                            start_chat_button_container = { visible: true }
-                            resume_chat_button_container = { visible: false }
-                            download_button_container = { visible: false }
+                            download_pending_button = { visible: false }
+                            start_chat_button = { visible: true }
+                            resume_chat_button = { visible: false }
+                            download_button = { visible: false }
                         }},
                     );
                 }
@@ -165,10 +165,10 @@ impl ModelFilesList {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button_container = { visible: false }
-                        start_chat_button_container = { visible: false }
-                        resume_chat_button_container = { visible: false }
-                        download_button_container = { visible: true }
+                        download_pending_button = { visible: false }
+                        start_chat_button = { visible: false }
+                        resume_chat_button = { visible: false }
+                        download_button = { visible: true }
                     }},
                 );
             };

--- a/moxin-frontend/src/shared/widgets.rs
+++ b/moxin-frontend/src/shared/widgets.rs
@@ -139,6 +139,62 @@ live_design! {
         }
     }
 
+    // Customized button widget, based on the RoundedView shaders with some modifications
+    // which is a better fit with our application UI design
+    MoxinButton = <Button> {
+        draw_bg: {
+            instance color: #0000
+            instance color_hover: #fff
+            instance border_width: 1.0
+            instance border_color: #0000
+            instance border_color_hover: #fff
+            instance radius: 2.5
+
+            fn get_color(self) -> vec4 {
+                return mix(self.color, mix(self.color, self.color_hover, 0.2), self.hover)
+            }
+
+            fn get_border_color(self) -> vec4 {
+                return mix(self.border_color, mix(self.border_color, self.border_color_hover, 0.2), self.hover)
+            }
+
+            fn pixel(self) -> vec4 {
+                let sdf = Sdf2d::viewport(self.pos * self.rect_size)
+                sdf.box(
+                    self.border_width,
+                    self.border_width,
+                    self.rect_size.x - (self.border_width * 2.0),
+                    self.rect_size.y - (self.border_width * 2.0),
+                    max(1.0, self.radius)
+                )
+                sdf.fill_keep(self.get_color())
+                if self.border_width > 0.0 {
+                    sdf.stroke(self.get_border_color(), self.border_width)
+                }
+                return sdf.result;
+            }
+        }
+
+        draw_icon: {
+            instance color: #fff
+            fn get_color(self) -> vec4 {
+                return mix(
+                    self.color,
+                    mix(self.color, #f, 0.2),
+                    self.hover
+                )
+            }
+        }
+        icon_walk: {width: 14, height: 14}
+
+        draw_text: {
+            text_style: <REGULAR_FONT>{font_size: 9},
+            fn get_color(self) -> vec4 {
+                return #fff;
+            }
+        }
+    }
+
     // Customized text input
     // Removes shadows, focus highlight and the dark theme colors
     MoxinTextInput = <TextInput> {

--- a/moxin-frontend/src/shared/widgets.rs
+++ b/moxin-frontend/src/shared/widgets.rs
@@ -190,7 +190,7 @@ live_design! {
         draw_text: {
             text_style: <REGULAR_FONT>{font_size: 9},
             fn get_color(self) -> vec4 {
-                return #fff;
+                return self.color;
             }
         }
     }


### PR DESCRIPTION
This PR replaces some of the buttons in the Explore and Download Manager sections to make use of the original widget from Makepad.

It defines a custom `MoxinButton` which is basically a `Button` widget with most of the shader code reimplemented to fit our application design. It follows what we did for the `TextInput` widget (where we have a `MoxinTextInput`).

Now, it has a better look&feel because hovering those buttons has animations in the colors. At the code level, it relying in most idiomatic Makepad code since it is using the `Button` API directly.